### PR TITLE
Close docs and release guardrail issues

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @jmcte
+/browser-bridge/ @jmcte

--- a/browser-bridge/ARCHIVED
+++ b/browser-bridge/ARCHIVED
@@ -1,0 +1,9 @@
+browser-bridge is archived.
+
+This directory contains the legacy browser extension bridge retained for
+migration audits and historical reference only. It is not part of the supported
+APW v2 runtime, release gates, or packaging path.
+
+Do not add new behavior here. If a future release needs browser integration
+again, create a new maintained component with explicit CI instead of reviving
+this archived bridge in place.

--- a/docs/ARCHIVE_POLICY.md
+++ b/docs/ARCHIVE_POLICY.md
@@ -6,6 +6,10 @@ The full archived, non-maintained implementation is at:
 
 - `legacy/deno/` (repo path)
 
+The browser bridge is also archived in place:
+
+- `browser-bridge/` (repo path)
+
 ## Purpose of archive
 
 - Preserve the original Deno implementation as a compatibility and audit reference.
@@ -15,9 +19,11 @@ The full archived, non-maintained implementation is at:
 ## Maintenance rules
 
 - `legacy/deno/` is read-only by default.
+- `browser-bridge/` is read-only by default and carries an in-directory
+  `ARCHIVED` tombstone.
 - No feature work or new behavior should be introduced there.
 - CI, lint, build, and packaging should target `rust/` only.
-- Use `legacy/deno/` only for:
+- Use `legacy/deno/` or `browser-bridge/` only for:
   - behavior audits,
   - historical diffing,
   - explicit, manual compatibility re-runs.
@@ -27,6 +33,8 @@ The full archived, non-maintained implementation is at:
 - Never treat archive behavior as a source of truth for releases.
 - Do not apply dependency or security hardening changes only in the archive.
 - All release gates, changelog updates, and bug fixes must land in Rust.
+- `CODEOWNERS` explicitly owns `browser-bridge/` so archive changes require
+  code-owner review even though the bridge has no active product CI.
 
 ## First-run policy (for maintainers)
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -66,7 +66,7 @@ This validates:
 
 ### Publish your own tap
 
-Use [`packaging/homebrew/apw.rb`](/Users/johnteneyckjr./src/apw/packaging/homebrew/apw.rb)
+Use [`packaging/homebrew/apw.rb`](../packaging/homebrew/apw.rb)
 as the formula template.
 
 After installing with Homebrew, install the per-user APW app bundle:

--- a/docs/MIGRATION_AND_PARITY.md
+++ b/docs/MIGRATION_AND_PARITY.md
@@ -8,12 +8,12 @@ Release reference version: `v2.0.0`
 
 ## Current maintenance policy
 
-- Supported v2 implementation: [`rust/`](/Users/johnteneyckjr./src/apw/rust) + `native-app/`
-- Archived implementation: [`legacy/deno/`](/Users/johnteneyckjr./src/apw/legacy/deno)
+- Supported v2 implementation: [`rust/`](../rust/) + `native-app/`
+- Archived implementation: [`legacy/deno/`](../legacy/deno/)
 - Packaging, release, fixes, and hardening land in the Rust CLI and native app
 - Legacy daemon/browser-helper code remains in-tree for migration only
 
-Archive rules: [docs/ARCHIVE_POLICY.md](/Users/johnteneyckjr./src/apw/docs/ARCHIVE_POLICY.md)
+Archive rules: [ARCHIVE_POLICY.md](ARCHIVE_POLICY.md)
 
 ## Parity target
 
@@ -27,7 +27,7 @@ The `v2.0.0` line intentionally changes that contract:
 - OTP parity is not guaranteed
 
 The command migration matrix is tracked in
-[docs/NATIVE_MIGRATION.md](/Users/johnteneyckjr./src/apw/docs/NATIVE_MIGRATION.md).
+[NATIVE_MIGRATION.md](NATIVE_MIGRATION.md).
 
 ## Automated coverage
 
@@ -57,6 +57,6 @@ Before tagging a public release:
 
 Related docs:
 
-- [docs/INSTALLATION.md](/Users/johnteneyckjr./src/apw/docs/INSTALLATION.md)
-- [docs/SECURITY_POSTURE_AND_TESTING.md](/Users/johnteneyckjr./src/apw/docs/SECURITY_POSTURE_AND_TESTING.md)
-- [docs/NATIVE_MIGRATION.md](/Users/johnteneyckjr./src/apw/docs/NATIVE_MIGRATION.md)
+- [INSTALLATION.md](INSTALLATION.md)
+- [SECURITY_POSTURE_AND_TESTING.md](SECURITY_POSTURE_AND_TESTING.md)
+- [NATIVE_MIGRATION.md](NATIVE_MIGRATION.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# APW documentation
+
+Start here for the maintained APW v2 documentation set.
+
+- [Installation and operation](INSTALLATION.md)
+- [Security posture and testing](SECURITY_POSTURE_AND_TESTING.md)
+- [Threat model](THREAT_MODEL.md)
+- [Native migration matrix](NATIVE_MIGRATION.md)
+- [Native-only redesign notes](NATIVE_ONLY_REDESIGN.md)
+- [Rust migration and parity](MIGRATION_AND_PARITY.md)
+- [Archive policy](ARCHIVE_POLICY.md)
+- [Standalone breakout notes](STANDALONE_BREAKOUT.md)
+
+Bootstrap and contributor environment notes live under
+[`bootstrap/`](bootstrap/).

--- a/docs/SECURITY_POSTURE_AND_TESTING.md
+++ b/docs/SECURITY_POSTURE_AND_TESTING.md
@@ -59,4 +59,4 @@ The Rust test suite covers:
 The Deno implementation is archived and not part of the supported security
 surface. Use it only for compatibility audit work.
 
-Archive rules: [docs/ARCHIVE_POLICY.md](/Users/johnteneyckjr./src/apw/docs/ARCHIVE_POLICY.md)
+Archive rules: [ARCHIVE_POLICY.md](ARCHIVE_POLICY.md)

--- a/docs/STANDALONE_BREAKOUT.md
+++ b/docs/STANDALONE_BREAKOUT.md
@@ -60,6 +60,6 @@ git push -u origin main
 
 Related docs:
 
-- [README.md](/Users/johnteneyckjr./src/apw/README.md)
-- [docs/MIGRATION_AND_PARITY.md](/Users/johnteneyckjr./src/apw/docs/MIGRATION_AND_PARITY.md)
-- [docs/SECURITY_POSTURE_AND_TESTING.md](/Users/johnteneyckjr./src/apw/docs/SECURITY_POSTURE_AND_TESTING.md)
+- [README.md](../README.md)
+- [MIGRATION_AND_PARITY.md](MIGRATION_AND_PARITY.md)
+- [SECURITY_POSTURE_AND_TESTING.md](SECURITY_POSTURE_AND_TESTING.md)

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,0 +1,68 @@
+# APW threat model
+
+This document describes the APW v2 credential-broker security boundary.
+
+Release reference version: `v2.0.0`
+
+## Assets
+
+- iCloud Keychain password credentials for app-associated domains.
+- Same-user broker requests and responses over the local APW socket.
+- APW runtime config under `~/.apw/config.json`.
+- Optional external password-manager fallback output.
+
+APW is scoped to credentials the signed macOS app is entitled to request through
+Apple associated-domain and AuthenticationServices policy. Domains outside the
+embedded entitlements are out of scope for credential access.
+
+## Trust boundaries
+
+- CLI to native app: same-user local IPC under `~/.apw/native-app/`.
+- Native app to Apple Passwords: public Apple frameworks and system-mediated
+  credential UI.
+- CLI to external fallback provider: opt-in subprocess execution from an
+  absolute configured path.
+- Repository to release artifact: build, signing, notarization, and package
+  publication gates.
+
+## Attacker models
+
+- Local unprivileged user on the same machine attempting cross-user credential
+  access.
+- Malicious or corrupted `~/.apw/config.json` attempting to redirect fallback
+  provider execution.
+- Rogue local process attempting to impersonate the broker socket or replay a
+  credential response.
+- Operator error during domain expansion, signing, notarization, or release
+  packaging.
+
+## In scope
+
+- Rejecting unsupported domains before a credential is returned.
+- Returning typed failures for malformed IPC, unsupported URLs, denied requests,
+  and broker timeouts.
+- Keeping broker and runtime files same-user scoped.
+- Requiring explicit user mediation before credential release.
+- Validating external fallback provider configuration before execution.
+
+## Out of scope
+
+- Cross-user access to another macOS account's keychain.
+- Remote exploitation of Apple Passwords or AuthenticationServices.
+- Credentials for domains not present in the app's associated-domain
+  entitlement.
+- Bypassing Apple's domain-verification or system credential-selection policy.
+
+## Domain expansion
+
+Adding a production domain requires all of these steps:
+
+1. Add the domain to the app's Associated Domains entitlement.
+2. Serve a valid `apple-app-site-association` file from that domain.
+3. Rebuild and re-sign the app with the updated entitlement.
+4. Re-notarize and staple the app bundle before release.
+5. Validate the domain with `apw doctor` or the extended validation suite before
+   publishing.
+
+Config may narrow the active domain set, but it must not claim domains beyond
+the embedded entitlement.

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -20,6 +20,11 @@
     - Keep PR checks cheap. Add heavy validation to `scripts/ci/run-extended-validation.sh` instead of the PR lane.
     - APW extended validation now requires both Rust (`cargo`) and the macOS Swift toolchain, so the `extended-checks` job must stay on a GitHub-hosted macOS runner rather than the Synology shell-only pool.
 
+    ## Release Prep
+
+    - Run `scripts/bump-version.sh <version>` from the repository root to update all version-bearing release surfaces.
+    - Run `bash scripts/ci/run-fast-checks.sh` after version bumps before opening a release PR.
+
     ## Home Profiles
 
     - Run `project-bootstrap apply home --manifest ./project.bootstrap.yaml` after reviewing the bundled profile content.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+usage() {
+  echo "Usage: scripts/bump-version.sh <semver>" >&2
+}
+
+if [ "$#" -ne 1 ]; then
+  usage
+  exit 2
+fi
+
+new_version="$1"
+if [[ ! "$new_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Version must be semver without a leading v, for example 2.1.0." >&2
+  exit 2
+fi
+export NEW_VERSION="$new_version"
+
+files=(
+  rust/Cargo.toml
+  rust/src/cli.rs
+  rust/src/types.rs
+  packaging/homebrew/apw.rb
+  README.md
+  docs/INSTALLATION.md
+  docs/MIGRATION_AND_PARITY.md
+)
+
+backup_dir="$(mktemp -d)"
+restore_backups() {
+  for file in "${files[@]}"; do
+    if [ -f "$backup_dir/$file" ]; then
+      cp "$backup_dir/$file" "$file"
+    fi
+  done
+  rm -rf "$backup_dir"
+}
+trap restore_backups ERR
+trap 'rm -rf "$backup_dir"' EXIT
+
+for file in "${files[@]}"; do
+  mkdir -p "$backup_dir/$(dirname "$file")"
+  cp "$file" "$backup_dir/$file"
+done
+
+perl -0pi -e 's/^version = "\d+\.\d+\.\d+"/version = "$ENV{NEW_VERSION}"/m' rust/Cargo.toml
+perl -0pi -e 's/(refs\/tags\/v)\d+\.\d+\.\d+(\.tar\.gz)/$1$ENV{NEW_VERSION}$2/g; s/(version\s+")\d+\.\d+\.\d+(")/$1$ENV{NEW_VERSION}$2/g' packaging/homebrew/apw.rb
+perl -0pi -e 's/v\d+\.\d+\.\d+/v$ENV{NEW_VERSION}/g' README.md
+perl -0pi -e 's/v\d+\.\d+\.\d+/v$ENV{NEW_VERSION}/g' docs/INSTALLATION.md
+perl -0pi -e 's/v\d+\.\d+\.\d+/v$ENV{NEW_VERSION}/g' docs/MIGRATION_AND_PARITY.md
+
+./.github/scripts/verify-version-sync.sh \
+  rust/Cargo.toml \
+  rust/src/cli.rs \
+  rust/src/types.rs \
+  packaging/homebrew/apw.rb \
+  README.md \
+  docs/INSTALLATION.md \
+  docs/MIGRATION_AND_PARITY.md
+
+for file in "${files[@]}"; do
+  if cmp -s "$backup_dir/$file" "$file"; then
+    echo "unchanged $file"
+  else
+    echo "updated $file"
+    diff -u "$backup_dir/$file" "$file" | sed -nE '/^[+-][^+-]/p' || true
+  fi
+done

--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -6,6 +6,16 @@ cd "$ROOT_DIR"
 
 echo "Running APW fast checks..."
 
+if find . -path './.git' -prune -o -name '*.md' -print0 | xargs -0 grep -In '/Users/'; then
+  echo "Found machine-local absolute paths in markdown docs." >&2
+  exit 1
+fi
+
+if [ ! -x scripts/bump-version.sh ]; then
+  echo "scripts/bump-version.sh must be executable." >&2
+  exit 1
+fi
+
 chmod +x ./.github/scripts/verify-version-sync.sh
 ./.github/scripts/verify-version-sync.sh \
   rust/Cargo.toml \


### PR DESCRIPTION
## Summary
- add threat model docs and documentation index for associated-domain scope
- archive browser-bridge with a tombstone and explicit CODEOWNERS coverage
- remove machine-local markdown links and add a fast-check guard against /Users/ paths
- add scripts/bump-version.sh and document the release-prep version bump flow

Closes #4
Closes #5
Closes #10
Closes #11

## Validation
- bash scripts/ci/run-fast-checks.sh
- scripts/bump-version.sh 2.0.1 && scripts/bump-version.sh 2.0.0
- rg -n "/Users/" --glob "*.md" || true

## Risks / Notes
- docs and shell tooling only; no runtime credential broker behavior changed
