### PR TITLE
Route APW macOS CI to self-hosted pool

### DIFF
--- a/.github/workflows/extended-validation.yml
+++ b/.github/workflows/extended-validation.yml
@@ -89,7 +89,7 @@ jobs:
 
   extended-checks:
     name: Extended Checks
-    runs-on: ['self-hosted', 'public', 'macOS', 'ARM64', 'xcode']
+    runs-on: ['self-hosted', 'private', 'macOS', 'ARM64', 'xcode']
     timeout-minutes: 40
     needs: changes
     if: needs.changes.outputs.extended == 'true' || needs.changes.outputs.app == 'true'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,19 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+
+      - name: Install Linux build tools
+        run: |
+          if command -v cc >/dev/null 2>&1; then
+            exit 0
+          fi
+          if command -v apt-get >/dev/null 2>&1; then
+            apt-get update
+            apt-get install -y build-essential pkg-config libssl-dev
+            exit 0
+          fi
+          echo "No C compiler found and no supported package manager is available." >&2
+          exit 1
       
       - name: Verify version sync
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
       
       - name: Verify version sync
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   lint:
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    # Hosted fallback: the Synology shell-only pool does not provide a C toolchain,
+    # and apt-based provisioning is blocked by container permissions.
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5
@@ -14,19 +16,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-
-      - name: Install Linux build tools
-        run: |
-          if command -v cc >/dev/null 2>&1; then
-            exit 0
-          fi
-          if command -v apt-get >/dev/null 2>&1; then
-            apt-get update
-            apt-get install -y build-essential pkg-config libssl-dev
-            exit 0
-          fi
-          echo "No C compiler found and no supported package manager is available." >&2
-          exit 1
       
       - name: Verify version sync
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -78,7 +78,7 @@ jobs:
 
   native-app-swift-tests:
     name: Native App Swift Tests
-    runs-on: ['self-hosted', 'public', 'macOS', 'ARM64', 'xcode']
+    runs-on: ['self-hosted', 'private', 'macOS', 'ARM64', 'xcode']
     timeout-minutes: 20
     needs: changes
     if: >-

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -23,7 +23,7 @@ defaults:
 jobs:
   changes:
     name: Detect Relevant Changes
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
     outputs:
       app: ${{ steps.filter.outputs.app }}
       ci: ${{ steps.filter.outputs.ci }}
@@ -58,7 +58,7 @@ jobs:
 
   fast-checks:
     name: Fast Checks
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
     timeout-minutes: 15
     needs: changes
     if: >-
@@ -94,7 +94,7 @@ jobs:
 
   validate-secrets:
     name: Validate Secrets
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
     timeout-minutes: 10
     if: github.event.pull_request.draft == false
     steps:
@@ -106,7 +106,7 @@ jobs:
 
   ci-gate:
     name: CI Gate
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
     if: always()
     needs:
       - changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ['self-hosted', 'public', 'macOS', 'ARM64', 'xcode']
+    runs-on: ['self-hosted', 'private', 'macOS', 'ARM64', 'xcode']
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -7,7 +7,9 @@ permissions:
 
 jobs:
   test:
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    # Hosted fallback: the Synology shell-only pool does not provide a C toolchain,
+    # and apt-based provisioning is blocked by container permissions.
+    runs-on: ubuntu-latest
 
     steps:
       - name: Setup repo
@@ -17,19 +19,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-
-      - name: Install Linux build tools
-        run: |
-          if command -v cc >/dev/null 2>&1; then
-            exit 0
-          fi
-          if command -v apt-get >/dev/null 2>&1; then
-            apt-get update
-            apt-get install -y build-essential pkg-config libssl-dev
-            exit 0
-          fi
-          echo "No C compiler found and no supported package manager is available." >&2
-          exit 1
 
       - name: Rust format check
         run: cargo fmt --manifest-path rust/Cargo.toml -- --check

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -18,6 +18,19 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Install Linux build tools
+        run: |
+          if command -v cc >/dev/null 2>&1; then
+            exit 0
+          fi
+          if command -v apt-get >/dev/null 2>&1; then
+            apt-get update
+            apt-get install -y build-essential pkg-config libssl-dev
+            exit 0
+          fi
+          echo "No C compiler found and no supported package manager is available." >&2
+          exit 1
+
       - name: Rust format check
         run: cargo fmt --manifest-path rust/Cargo.toml -- --check
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
 
     steps:
       - name: Setup repo

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
       - name: Rust format check
         run: cargo fmt --manifest-path rust/Cargo.toml -- --check

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -18,7 +18,7 @@
     - Shell-safe jobs may use `[self-hosted, synology, shell-only, public]`.
     - Docker, service-container, browser, and `container:` workloads stay on GitHub-hosted runners.
     - Keep PR checks cheap. Add heavy validation to `scripts/ci/run-extended-validation.sh` instead of the PR lane.
-    - APW extended validation now requires both Rust (`cargo`) and the macOS Swift toolchain, so the `extended-checks` job must stay on a GitHub-hosted macOS runner rather than the Synology shell-only pool.
+    - APW extended validation requires both Rust (`cargo`) and the macOS Swift toolchain, so the `extended-checks` job must run on the org macOS self-hosted pool (`[self-hosted, private, macOS, ARM64, xcode]`) rather than the Synology shell-only pool.
 
     ## Release Prep
 


### PR DESCRIPTION
## Summary
- route APW macOS CI/release jobs to the org private macOS self-hosted pool
- keep shell-safe Linux validation on the public Synology self-hosted pool
- update onboarding guidance to match the current runner topology

## Verification
- ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f); puts "ok #{f}" }'
- added OMT-Global/apw-cli to synology-public runner group 4
- added OMT-Global/apw-cli to macos-private runner group 5