### PR TITLE
Fix canonical Homebrew repo metadata

### DIFF
--- a/.github/scripts/verify-version-sync.sh
+++ b/.github/scripts/verify-version-sync.sh
@@ -29,6 +29,21 @@ extract_version_from_docs() {
   sed -nE 's/.*Release reference version:[^0-9]*`?v?([0-9]+\.[0-9]+\.[0-9]+)`?.*/\1/p' "$1" | head -n 1
 }
 
+require_canonical_repo_slug() {
+  local file="$1"
+  local slug="OMT-Global/apw-cli"
+
+  if ! grep -q "$slug" "$file"; then
+    printf 'Repository slug check failed: %s does not reference %s\n' "$file" "$slug" >&2
+    exit 1
+  fi
+
+  if grep -Eq 'OMT-Global/apw([^-/]|$)|omt-global/apw-native' "$file"; then
+    printf 'Repository slug check failed: %s references a stale APW repo slug\n' "$file" >&2
+    exit 1
+  fi
+}
+
 cargo_version="$(extract_version_from_cargo "$1")"
 cli_version="$(extract_version_from_rust_source "$2")"
 types_version="$(extract_version_from_rust_source "$3")"
@@ -52,5 +67,8 @@ Version sync check failed:
 EOF
   exit 1
 fi
+
+require_canonical_repo_slug "$4"
+require_canonical_repo_slug "packaging/homebrew/install-from-source.sh"
 
 echo "Version sync check passed: $cargo_version"

--- a/packaging/homebrew/apw.rb
+++ b/packaging/homebrew/apw.rb
@@ -1,8 +1,8 @@
 class Apw < Formula
   desc "Apple Password CLI and local app broker (macOS-first)"
-  homepage "https://github.com/OMT-Global/apw"
+  homepage "https://github.com/OMT-Global/apw-cli"
   version "2.0.0"
-  url "https://github.com/OMT-Global/apw/archive/refs/tags/v2.0.0.tar.gz"
+  url "https://github.com/OMT-Global/apw-cli/archive/refs/tags/v2.0.0.tar.gz"
   sha256 "<replace-with-release-tarball-sha256>"
   license "GPL-3.0-only"
 

--- a/packaging/homebrew/install-from-source.sh
+++ b/packaging/homebrew/install-from-source.sh
@@ -36,8 +36,8 @@ TAP_PATH="$CLEANUP_TAP_PATH"
 mkdir -p "$TAP_PATH/Formula"
 cat > "$TAP_PATH/Formula/$FORMULA_NAME.rb" <<EOF
 class Apw < Formula
-  desc "Apple Password CLI and daemon (macOS-first)"
-  homepage "https://github.com/omt-global/apw-native"
+  desc "Apple Password CLI and local app broker (macOS-first)"
+  homepage "https://github.com/OMT-Global/apw-cli"
   version "$VERSION"
   url "file://$ARCHIVE_PATH"
   sha256 "$ARCHIVE_SHA256"
@@ -46,12 +46,15 @@ class Apw < Formula
   depends_on "rust" => :build
 
   def install
+    system "bash", "./scripts/build-native-app.sh"
     system "cargo", "build", "--manifest-path", "rust/Cargo.toml", "--release"
     bin.install "rust/target/release/apw"
+    libexec.install "native-app/dist/APW.app"
   end
 
   test do
-    assert_match(/^apw/, shell_output("#{bin}/apw --version"))
+    assert_match version.to_s, shell_output("#{bin}/apw --version")
+    assert_match "\"app\"", shell_output("#{bin}/apw status --json 2>&1")
   end
 end
 EOF


### PR DESCRIPTION
## Summary
- update checked-in Homebrew formula URLs to OMT-Global/apw-cli
- update source-smoke formula metadata and install/test shape to match the native app broker package
- extend version-sync validation to fail on stale APW repo slugs

Closes #22

## Validation
- bash scripts/ci/run-fast-checks.sh
- git diff --check

## Risks / Notes
- Packaging metadata and shell validation only; no runtime credential behavior changed.