### PR TITLE
Enforce HTTPS and fill native broker requests

### DIFF
--- a/native-app/Sources/NativeAppLib/BrokerCore.swift
+++ b/native-app/Sources/NativeAppLib/BrokerCore.swift
@@ -224,7 +224,10 @@ final class BrokerServer {
       )
     case "login":
       let url = request.payload?["url"] ?? ""
-      return try loginResponse(for: url, requestId: request.requestId)
+      return try credentialResponse(for: url, intent: "login", requestId: request.requestId)
+    case "fill":
+      let url = request.payload?["url"] ?? ""
+      return try credentialResponse(for: url, intent: "fill", requestId: request.requestId)
     default:
       return ResponseEnvelope(
         ok: false,
@@ -263,13 +266,27 @@ final class BrokerServer {
     ]
   }
 
-  private func loginResponse(for rawURL: String, requestId: String?) throws -> ResponseEnvelope {
+  private func credentialResponse(
+    for rawURL: String,
+    intent: String,
+    requestId: String?
+  ) throws -> ResponseEnvelope {
     guard let url = URL(string: rawURL), let host = url.host?.lowercased(), !host.isEmpty else {
       return ResponseEnvelope(
         ok: false,
         code: 1,
         payload: nil,
-        error: "Invalid URL for native app login.",
+        error: "Invalid URL for native app credential request.",
+        requestId: requestId
+      )
+    }
+
+    guard url.scheme?.lowercased() == "https" else {
+      return ResponseEnvelope(
+        ok: false,
+        code: 1,
+        payload: nil,
+        error: "Native app credential requests require https URLs.",
         requestId: requestId
       )
     }
@@ -312,6 +329,7 @@ final class BrokerServer {
       code: 0,
       payload: [
         "status": AnyCodable("approved"),
+        "intent": AnyCodable(intent),
         "url": AnyCodable(credential.url),
         "domain": AnyCodable(credential.domain),
         "username": AnyCodable(credential.username),

--- a/native-app/Tests/NativeAppTests/BrokerCoreTests.swift
+++ b/native-app/Tests/NativeAppTests/BrokerCoreTests.swift
@@ -144,6 +144,7 @@ final class BrokerCoreTests: XCTestCase {
       payload: ["url": "https://example.com"]
     ))
     XCTAssertEqual(allowResponse.ok, true)
+    XCTAssertEqual(allowResponse.payload?["intent"]?.value as? String, "login")
 
     let denyServer = makeServer(root: root, decision: false)
     let denyResponse = try denyServer.dispatch(request: RequestEnvelope(
@@ -153,6 +154,42 @@ final class BrokerCoreTests: XCTestCase {
     ))
     XCTAssertEqual(denyResponse.ok, false)
     XCTAssertEqual(denyResponse.error, "User denied the APW login request.")
+  }
+
+  func testFillDispatchUsesFillIntent() throws {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let paths = makePaths(root)
+    try writeCredentials(at: paths.credentialsPath)
+
+    let server = makeServer(root: root, decision: true)
+    let response = try server.dispatch(request: RequestEnvelope(
+      requestId: "fill",
+      command: "fill",
+      payload: ["url": "https://example.com"]
+    ))
+
+    XCTAssertEqual(response.ok, true)
+    XCTAssertEqual(response.payload?["intent"]?.value as? String, "fill")
+    XCTAssertEqual(response.payload?["domain"]?.value as? String, "example.com")
+  }
+
+  func testCredentialRequestsRejectNonHttpsUrls() throws {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let paths = makePaths(root)
+    try writeCredentials(at: paths.credentialsPath)
+
+    let server = makeServer(root: root, decision: true)
+    for command in ["login", "fill"] {
+      let response = try server.dispatch(request: RequestEnvelope(
+        requestId: command,
+        command: command,
+        payload: ["url": "ftp://example.com"]
+      ))
+      XCTAssertEqual(response.ok, false)
+      XCTAssertEqual(response.error, "Native app credential requests require https URLs.")
+    }
   }
 
   func testDoctorPayloadDoesNotAdvertiseAmbientAutoApproveEscapeHatch() throws {

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -90,6 +90,23 @@ fn sanitize_url(raw: &str) -> Result<String, APWError> {
     Ok(candidate)
 }
 
+fn sanitize_native_credential_url(raw: &str) -> Result<String, APWError> {
+    let candidate = sanitize_url(raw)?;
+    let parsed = url::Url::parse(&candidate).map_err(|_| {
+        APWError::new(
+            Status::InvalidParam,
+            format!("Invalid native credential URL: '{candidate}'"),
+        )
+    })?;
+    if parsed.scheme() != "https" {
+        return Err(APWError::new(
+            Status::InvalidParam,
+            "Native credential requests require an https URL.",
+        ));
+    }
+    Ok(candidate)
+}
+
 fn print_output(payload: &serde_json::Value, status: Status, json_output: bool) {
     if json_output {
         println!(
@@ -411,14 +428,14 @@ fn run_fill(args: FillCommand, cli_json: bool) -> Result<(), APWError> {
         "fill",
         format!("requesting fill credential for {}", args.url),
     );
-    let payload = native_app_fill(&sanitize_url(&args.url)?)?;
+    let payload = native_app_fill(&sanitize_native_credential_url(&args.url)?)?;
     print_output(&payload, Status::Success, cli_json);
     Ok(())
 }
 
 fn run_login(args: LoginCommand, cli_json: bool) -> Result<(), APWError> {
     logging::info("login", format!("requesting credential for {}", args.url));
-    let payload = native_app_login(&sanitize_url(&args.url)?)?;
+    let payload = native_app_login(&sanitize_native_credential_url(&args.url)?)?;
     print_output(&payload, Status::Success, cli_json);
     Ok(())
 }
@@ -729,6 +746,20 @@ mod tests {
     fn parse_url_is_optional_https_default() {
         assert_eq!(sanitize_url("example.com").unwrap(), "https://example.com");
         assert!(sanitize_url("not a url").is_err());
+    }
+
+    #[test]
+    fn native_credential_urls_must_be_https() {
+        assert_eq!(
+            sanitize_native_credential_url("example.com").unwrap(),
+            "https://example.com"
+        );
+        assert_eq!(
+            sanitize_native_credential_url("https://example.com/login").unwrap(),
+            "https://example.com/login"
+        );
+        assert!(sanitize_native_credential_url("http://example.com").is_err());
+        assert!(sanitize_native_credential_url("ftp://example.com").is_err());
     }
 
     #[test]

--- a/rust/tests/native_app_e2e.rs
+++ b/rust/tests/native_app_e2e.rs
@@ -94,7 +94,13 @@ def login_payload(raw_url, transport):
         return {
             "ok": False,
             "code": 1,
-            "error": "Invalid URL for native app login.",
+            "error": "Invalid URL for native app credential request.",
+        }
+    if parsed.scheme.lower() != "https":
+        return {
+            "ok": False,
+            "code": 1,
+            "error": "Native app credential requests require https URLs.",
         }
     if host != "example.com":
         return {
@@ -604,6 +610,25 @@ fn login_reports_operator_facing_failures() {
         .as_str()
         .unwrap_or_default()
         .contains("User denied"));
+}
+
+#[test]
+#[serial]
+fn native_credential_commands_reject_non_https_urls() {
+    let fixture = NativeAppFixture::new();
+
+    let install = run_apw(&fixture, &["--json", "app", "install"], &[]);
+    assert_eq!(install.status, 0, "{install:#?}");
+
+    for command in ["login", "fill"] {
+        let result = run_apw(&fixture, &["--json", command, "ftp://example.com"], &[]);
+        assert_eq!(result.status, 2, "{result:#?}");
+        let payload = parse_error(&result);
+        assert!(payload["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("require an https URL"));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- require HTTPS URLs before Rust sends native login/fill credential requests
- add real Swift broker dispatch for fill using the same approved credential path as login
- add Swift and Rust regression coverage for fill intent and non-HTTPS rejection

Closes #19
Closes #20

## Validation
- bash scripts/ci/run-fast-checks.sh
- swift test --package-path native-app
- cargo test --manifest-path rust/Cargo.toml native_credential_urls_must_be_https -- --nocapture
- cargo test --manifest-path rust/Cargo.toml native_credential_commands_reject_non_https_urls -- --nocapture
- cargo test --manifest-path rust/Cargo.toml fill_request_includes_fill_intent -- --nocapture
- cargo test --manifest-path rust/Cargo.toml (outside sandbox; sandbox run failed on socket/process permission errors)
- git diff --check

## Risks / Notes
- Narrows native credential release to HTTPS only; bare domains still normalize to https://.
- Uses the existing demo credential source and approval prompt; real AuthenticationServices integration remains tracked separately.