### PR TITLE
Document and test native IPC timeouts

### DIFF
--- a/docs/SECURITY_POSTURE_AND_TESTING.md
+++ b/docs/SECURITY_POSTURE_AND_TESTING.md
@@ -27,6 +27,15 @@ Release reference version: `v2.0.0`
 - requests and responses use typed JSON envelopes with bounded payload sizes
 - bootstrap credentials are stored in a local runtime file for the supported demo domain only
 
+### Timeouts and failure modes
+
+- native app UNIX-socket requests use a `3s` read/write timeout
+- a hung broker socket returns a non-zero `CommunicationTimeout` error instead
+  of blocking the CLI indefinitely
+- direct executable fallback responses are still bounded by the same maximum
+  response size before JSON decoding
+- timed-out requests do not cache or persist partially returned credentials
+
 ## Required release gates
 
 Run these before publishing:
@@ -50,6 +59,7 @@ The Rust test suite covers:
 - stable JSON status shape
 - launch failure precedence over session errors
 - malformed or oversized payload rejection
+- native app socket timeout handling
 - native app diagnostics and bootstrap credential file initialization
 - end-to-end v2 app install, launch, status, doctor, and login flows
 - direct-exec fallback, unsupported-domain handling, denial handling, and malformed broker response mapping

--- a/native-app/Sources/NativeAppLib/BrokerCore.swift
+++ b/native-app/Sources/NativeAppLib/BrokerCore.swift
@@ -6,6 +6,7 @@ import Foundation
 private let runtimeDirectoryMode: mode_t = 0o700
 private let statusFileMode: mode_t = 0o600
 private let maxBrokerBytes = 32 * 1024
+private let brokerRequestTimeoutSeconds: TimeInterval = 3
 private let appSocketName = "broker.sock"
 private let statusFileName = "status.json"
 private let credentialsFileName = "credentials.json"
@@ -245,6 +246,7 @@ final class BrokerServer {
       "socketPath": paths.socketPath.path,
       "supportedDomains": supportedDomains(),
       "authenticationServicesLinked": true,
+      "requestTimeoutSeconds": brokerRequestTimeoutSeconds,
     ]
   }
 

--- a/native-app/Tests/NativeAppTests/BrokerCoreTests.swift
+++ b/native-app/Tests/NativeAppTests/BrokerCoreTests.swift
@@ -162,8 +162,10 @@ final class BrokerCoreTests: XCTestCase {
 
     let payload = server.doctorPayload()
     let guidance = payload["guidance"] as? [String]
+    let broker = payload["broker"] as? [String: Any]
 
     XCTAssertNotNil(guidance)
     XCTAssertFalse(guidance?.contains(where: { $0.contains("APW_NATIVE_APP_AUTO_APPROVE") }) ?? true)
+    XCTAssertEqual(broker?["requestTimeoutSeconds"] as? TimeInterval, 3)
   }
 }

--- a/rust/src/native_app.rs
+++ b/rust/src/native_app.rs
@@ -24,7 +24,7 @@ const NATIVE_APP_RUNTIME_DIR_MODE: u32 = 0o700;
 const NATIVE_APP_FILE_MODE: u32 = 0o600;
 const MAX_BROKER_BYTES: usize = MAX_MESSAGE_BYTES;
 const MAX_BROKER_LOG_BYTES: u64 = 10 * 1024 * 1024;
-const SOCKET_TIMEOUT_MS: u64 = 3_000;
+const NATIVE_APP_SOCKET_TIMEOUT_MS: u64 = 3_000;
 const CONNECT_RETRIES: usize = 10;
 const CONNECT_RETRY_DELAY_MS: u64 = 200;
 
@@ -386,7 +386,7 @@ fn send_request(command: &str, payload: Value) -> Result<Value> {
         Some(connection) => connection,
         None => return send_request_via_executable(command, payload),
     };
-    let timeout = Duration::from_millis(SOCKET_TIMEOUT_MS);
+    let timeout = Duration::from_millis(NATIVE_APP_SOCKET_TIMEOUT_MS);
     let _ = stream.set_read_timeout(Some(timeout));
     let _ = stream.set_write_timeout(Some(timeout));
 
@@ -516,7 +516,8 @@ pub fn native_app_status() -> Value {
             "lastKnown": status_file,
             "live": live_status,
             "transport": "unix_socket",
-            "transportContract": "typed_json_envelope"
+            "transportContract": "typed_json_envelope",
+            "requestTimeoutMs": NATIVE_APP_SOCKET_TIMEOUT_MS
         }
     })
 }
@@ -1333,6 +1334,36 @@ print(json.dumps({
             assert_eq!(payload["transport"], "direct_exec");
 
             drop(listener);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn socket_request_times_out_when_broker_does_not_reply() {
+        with_temp_home(|| {
+            ensure_runtime_dir().unwrap();
+            let socket_path = native_app_socket_path();
+            let listener = UnixListener::bind(&socket_path).unwrap();
+            set_permissions(&socket_path, NATIVE_APP_FILE_MODE).unwrap();
+
+            let handle = std::thread::spawn(move || {
+                if let Ok((stream, _addr)) = listener.accept() {
+                    std::thread::sleep(Duration::from_millis(
+                        NATIVE_APP_SOCKET_TIMEOUT_MS.saturating_add(500),
+                    ));
+                    drop(stream);
+                }
+            });
+
+            let started = std::time::Instant::now();
+            let error = native_app_login("https://example.com").unwrap_err();
+            assert_eq!(error.code, Status::CommunicationTimeout);
+            assert!(
+                started.elapsed()
+                    < Duration::from_millis(NATIVE_APP_SOCKET_TIMEOUT_MS.saturating_add(2_000))
+            );
+
+            handle.join().unwrap();
         });
     }
 


### PR DESCRIPTION
## Summary
- expose the native broker request timeout in Rust status and Swift broker status payloads
- add a regression test proving a hung broker socket returns CommunicationTimeout instead of hanging indefinitely
- document timeout/failure behavior in the security posture guide

Closes #2

## Validation
- cargo fmt --manifest-path rust/Cargo.toml --check
- cargo test --manifest-path rust/Cargo.toml socket_request_times_out_when_broker_does_not_reply -- --nocapture (outside sandbox for UNIX socket bind/connect)
- swift test --package-path native-app
- bash scripts/ci/run-fast-checks.sh
- cargo test --manifest-path rust/Cargo.toml (outside sandbox for socket/process-heavy tests)
- git diff --check

## Risks / Notes
- This documents and tests the existing 3s UNIX-socket timeout; it does not change the timeout duration.