### PR TITLE
Gate demo credential file creation

### DIFF
--- a/docs/SECURITY_POSTURE_AND_TESTING.md
+++ b/docs/SECURITY_POSTURE_AND_TESTING.md
@@ -13,7 +13,10 @@ Release reference version: `v2.0.0`
 - legacy runtime config lives in `~/.apw/config.json`
 - the v2 app broker uses `~/.apw/native-app/`
 - `~/.apw` is created with mode `0700`
-- config, status, and bootstrap credential files are written with mode `0600`
+- config and status files are written with mode `0600`; plaintext bootstrap
+  credential files are never persisted by default
+- demo bootstrap credentials are written only when `APW_DEMO=1` is explicitly
+  set for bootstrap tests
 - legacy session secret material is kept in the user keychain when the `v1.x`
   compatibility path is used
 - external CLI fallback is opt-in via `fallbackProvider` +
@@ -25,7 +28,9 @@ Release reference version: `v2.0.0`
 - the v2 app broker uses a same-user local UNIX socket under `~/.apw/native-app/`
 - `status --json` exposes app/broker readiness while retaining legacy daemon diagnostics
 - requests and responses use typed JSON envelopes with bounded payload sizes
-- bootstrap credentials are stored in a local runtime file for the supported demo domain only
+- bootstrap credentials are read from a local runtime file for the supported
+  demo domain only; the app does not create that plaintext file on default
+  launch
 
 ### Timeouts and failure modes
 
@@ -60,7 +65,7 @@ The Rust test suite covers:
 - launch failure precedence over session errors
 - malformed or oversized payload rejection
 - native app socket timeout handling
-- native app diagnostics and bootstrap credential file initialization
+- native app diagnostics and `APW_DEMO=1` bootstrap credential file initialization
 - end-to-end v2 app install, launch, status, doctor, and login flows
 - direct-exec fallback, unsupported-domain handling, denial handling, and malformed broker response mapping
 

--- a/native-app/Sources/NativeAppLib/BrokerCore.swift
+++ b/native-app/Sources/NativeAppLib/BrokerCore.swift
@@ -363,8 +363,11 @@ final class BrokerServer {
     chmod(paths.runtimeRoot.path, runtimeDirectoryMode)
   }
 
-  private func ensureCredentialsFile() throws {
+  func ensureCredentialsFile() throws {
     guard !FileManager.default.fileExists(atPath: paths.credentialsPath.path) else {
+      return
+    }
+    guard ProcessInfo.processInfo.environment["APW_DEMO"] == "1" else {
       return
     }
     let content = CredentialsFile(

--- a/native-app/Tests/NativeAppTests/BrokerCoreTests.swift
+++ b/native-app/Tests/NativeAppTests/BrokerCoreTests.swift
@@ -28,6 +28,23 @@ final class BrokerCoreTests: XCTestCase {
     BrokerServer(paths: makePaths(root), approvalPrompter: StubApprovalPrompter(decision: decision))
   }
 
+  private func withDemoEnv(_ value: String?, run: () throws -> Void) rethrows {
+    let previousValue = getenv("APW_DEMO").map { String(cString: $0) }
+    if let value {
+      setenv("APW_DEMO", value, 1)
+    } else {
+      unsetenv("APW_DEMO")
+    }
+    defer {
+      if let previousValue {
+        setenv("APW_DEMO", previousValue, 1)
+      } else {
+        unsetenv("APW_DEMO")
+      }
+    }
+    try run()
+  }
+
   private func writeCredentials(
     at path: URL,
     mode: Int = 0o600,
@@ -108,6 +125,39 @@ final class BrokerCoreTests: XCTestCase {
     XCTAssertThrowsError(try server.loadCredentials()) { error in
       XCTAssertTrue(String(describing: error).contains("0600"))
     }
+  }
+
+  func testDemoCredentialsFileCreationRequiresDemoEnvironmentGate() throws {
+    let defaultRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let defaultPaths = makePaths(defaultRoot)
+    try FileManager.default.createDirectory(
+      at: defaultRoot,
+      withIntermediateDirectories: true,
+      attributes: nil
+    )
+
+    try withDemoEnv(nil) {
+      try makeServer(root: defaultRoot).ensureCredentialsFile()
+    }
+    XCTAssertFalse(FileManager.default.fileExists(atPath: defaultPaths.credentialsPath.path))
+
+    let demoRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let demoPaths = makePaths(demoRoot)
+    try FileManager.default.createDirectory(
+      at: demoRoot,
+      withIntermediateDirectories: true,
+      attributes: nil
+    )
+
+    try withDemoEnv("1") {
+      try makeServer(root: demoRoot).ensureCredentialsFile()
+    }
+    XCTAssertTrue(FileManager.default.fileExists(atPath: demoPaths.credentialsPath.path))
+    let credentials = try makeServer(root: demoRoot).loadCredentials()
+    XCTAssertEqual(credentials.demo, true)
+    XCTAssertEqual(credentials.credentials.first?.username, "demo@example.com")
   }
 
   func testSocketListenerSetupAndTeardownUses0600Permissions() throws {

--- a/rust/src/native_app.rs
+++ b/rust/src/native_app.rs
@@ -272,6 +272,9 @@ fn ensure_default_credentials_file() -> Result<()> {
     if path.exists() {
         return Ok(());
     }
+    if env::var("APW_DEMO").ok().as_deref() != Some("1") {
+        return Ok(());
+    }
     let content = serde_json::to_vec_pretty(&default_credentials_payload()).map_err(|error| {
         APWError::new(
             Status::InvalidConfig,
@@ -1065,16 +1068,52 @@ mod tests {
         result
     }
 
+    fn with_demo_env<F, R>(value: Option<&str>, run: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let previous_value = env::var("APW_DEMO").ok();
+        if let Some(value) = value {
+            env::set_var("APW_DEMO", value);
+        } else {
+            env::remove_var("APW_DEMO");
+        }
+        let result = run();
+        if let Some(value) = previous_value {
+            env::set_var("APW_DEMO", value);
+        } else {
+            env::remove_var("APW_DEMO");
+        }
+        result
+    }
+
     #[test]
     #[serial]
-    fn doctor_creates_default_credentials_file() {
+    fn doctor_does_not_create_default_credentials_file_without_demo_gate() {
         with_temp_home(|| {
-            let payload = native_app_doctor().unwrap();
-            assert_eq!(
-                payload["frameworks"]["authenticationServicesLinked"],
-                json!(true)
-            );
-            assert!(native_app_credentials_path().exists());
+            with_demo_env(None, || {
+                let payload = native_app_doctor().unwrap();
+                assert_eq!(
+                    payload["frameworks"]["authenticationServicesLinked"],
+                    json!(true)
+                );
+                assert!(!native_app_credentials_path().exists());
+            });
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn doctor_creates_default_credentials_file_with_demo_gate() {
+        with_temp_home(|| {
+            with_demo_env(Some("1"), || {
+                let payload = native_app_doctor().unwrap();
+                assert_eq!(
+                    payload["frameworks"]["authenticationServicesLinked"],
+                    json!(true)
+                );
+                assert!(native_app_credentials_path().exists());
+            });
         });
     }
 

--- a/rust/tests/native_app_e2e.rs
+++ b/rust/tests/native_app_e2e.rs
@@ -438,6 +438,7 @@ fn wait_for_socket_transport(fixture: &NativeAppFixture) -> Value {
 #[serial]
 fn doctor_bootstraps_runtime_without_installed_bundle() {
     let fixture = NativeAppFixture::new();
+    let credentials_path = fixture.home().join(".apw/native-app/credentials.json");
 
     let output = run_apw(&fixture, &["--json", "doctor"], &[]);
     assert_eq!(output.status, 0, "{output:#?}");
@@ -449,10 +450,11 @@ fn doctor_bootstraps_runtime_without_installed_bundle() {
         payload["payload"]["frameworks"]["authenticationServicesLinked"],
         true
     );
-    assert!(fixture
-        .home()
-        .join(".apw/native-app/credentials.json")
-        .exists());
+    assert!(!credentials_path.exists());
+
+    let demo_output = run_apw(&fixture, &["--json", "doctor"], &[("APW_DEMO", "1")]);
+    assert_eq!(demo_output.status, 0, "{demo_output:#?}");
+    assert!(credentials_path.exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- stop default broker/doctor paths from creating plaintext demo `credentials.json`
- keep demo bootstrap credential materialization behind explicit `APW_DEMO=1`
- add Swift and Rust regressions and update the security posture doc

Closes #14

## Validation
- `cargo fmt --manifest-path rust/Cargo.toml -- --check`
- `cargo test --manifest-path rust/Cargo.toml native_app::tests::doctor_ -- --nocapture`
- `cargo test --manifest-path rust/Cargo.toml native_app::tests -- --nocapture`
- `env CLANG_MODULE_CACHE_PATH=/private/tmp/apw-issue-14-clang-cache SWIFTPM_CACHE_PATH=/private/tmp/apw-issue-14-swiftpm-cache swift test --package-path native-app --filter NativeAppTests.BrokerCoreTests`
- `git diff --check`

## Notes
- SwiftPM and socket-heavy Rust tests needed reruns outside the sandbox for cache/socket access; focused tests passed after escalation.
