### PR TITLE
Include APW.app in release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,9 @@ jobs:
           ./rust/target/release/apw --version
           ./rust/target/release/apw status --json
 
+      - name: Build native app bundle
+        run: ./scripts/build-native-app.sh
+
       - name: Homebrew smoke install from source tarball
         env:
           APW_SRC_TARBALL: ${{ steps.source_tarball.outputs.path }}
@@ -135,8 +138,23 @@ jobs:
       - name: Package release archive
         run: |
           mkdir -p dist
+          rm -rf dist/apw dist/APW.app
           cp rust/target/release/apw dist/apw
-          tar -czf dist/apw-macos-${GITHUB_REF_NAME}.tar.gz -C dist apw
+          cp -R native-app/dist/APW.app dist/APW.app
+          tar -czf dist/apw-macos-${GITHUB_REF_NAME}.tar.gz -C dist apw APW.app
+
+      - name: Release artifact smoke
+        run: |
+          archive="dist/apw-macos-${GITHUB_REF_NAME}.tar.gz"
+          smoke_dir="$(mktemp -d)"
+          smoke_home="$(mktemp -d)"
+          trap 'rm -rf "$smoke_dir" "$smoke_home"' EXIT
+          tar -xzf "$archive" -C "$smoke_dir"
+          test -x "$smoke_dir/apw"
+          test -x "$smoke_dir/APW.app/Contents/MacOS/APW"
+          HOME="$smoke_home" "$smoke_dir/apw" --version
+          HOME="$smoke_home" "$smoke_dir/apw" status --json
+          HOME="$smoke_home" "$smoke_dir/apw" app install
 
       - name: Publish release assets
         uses: softprops/action-gh-release@v2

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -45,6 +45,28 @@ cargo install --path rust --locked
 apw app install
 ```
 
+## Install from a release archive
+
+Release archives are named `apw-macos-vX.Y.Z.tar.gz` and contain:
+
+```text
+apw
+APW.app/
+```
+
+Extract the archive and keep `apw` beside `APW.app` while installing the
+per-user app bundle:
+
+```bash
+tar -xzf apw-macos-vX.Y.Z.tar.gz
+./apw --version
+./apw status --json
+./apw app install
+```
+
+After `apw app install`, the CLI copies `APW.app` into
+`~/.apw/native-app/installed/APW.app`.
+
 ## Homebrew
 
 ### Local formula smoke test

--- a/rust/src/native_app.rs
+++ b/rust/src/native_app.rs
@@ -142,6 +142,7 @@ pub fn native_app_executable_in_bundle(bundle_path: &Path) -> PathBuf {
 fn resolve_packaged_native_app_bundle() -> Result<PathBuf> {
     let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let mut candidates = vec![
+        cwd.join(NATIVE_APP_BUNDLE_NAME),
         cwd.join("native-app")
             .join("dist")
             .join(NATIVE_APP_BUNDLE_NAME),
@@ -155,6 +156,7 @@ fn resolve_packaged_native_app_bundle() -> Result<PathBuf> {
 
     if let Ok(exe) = env::current_exe() {
         if let Some(parent) = exe.parent() {
+            candidates.push(parent.join(NATIVE_APP_BUNDLE_NAME));
             candidates.push(
                 parent
                     .join("../libexec")

--- a/rust/tests/native_app_e2e.rs
+++ b/rust/tests/native_app_e2e.rs
@@ -322,12 +322,20 @@ impl Drop for NativeAppFixture {
 }
 
 fn create_fake_bundle(workspace: &Path) {
-    let bundle = workspace
+    let contents = workspace
         .join("native-app")
         .join("dist")
         .join("APW.app")
         .join("Contents");
-    let macos = bundle.join("MacOS");
+    create_fake_bundle_contents(&contents);
+}
+
+fn create_fake_archive_bundle(workspace: &Path) {
+    create_fake_bundle_contents(&workspace.join("APW.app").join("Contents"));
+}
+
+fn create_fake_bundle_contents(contents: &Path) {
+    let macos = contents.join("MacOS");
     fs::create_dir_all(&macos).expect("failed to create fake app bundle");
 
     let executable = macos.join("APW");
@@ -338,7 +346,7 @@ fn create_fake_bundle(workspace: &Path) {
     permissions.set_mode(0o755);
     fs::set_permissions(&executable, permissions).expect("failed to chmod fake app executable");
 
-    let info_plist = bundle.join("Info.plist");
+    let info_plist = contents.join("Info.plist");
     fs::write(
         info_plist,
         r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -479,6 +487,43 @@ fn app_install_copies_packaged_bundle_and_updates_status() {
         status_payload["payload"]["app"]["service"]["running"],
         false
     );
+}
+
+#[test]
+#[serial]
+fn app_install_finds_release_archive_sibling_bundle() {
+    let home = TempDir::new().expect("failed to create temp home");
+    let archive = TempDir::new().expect("failed to create temp archive");
+    let archive_apw = archive.path().join("apw");
+    fs::copy(apw_path(), &archive_apw).expect("failed to copy apw binary into archive fixture");
+    let mut permissions = fs::metadata(&archive_apw)
+        .expect("failed to stat copied apw binary")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&archive_apw, permissions).expect("failed to chmod copied apw binary");
+    create_fake_archive_bundle(archive.path());
+
+    let output = Command::new(&archive_apw)
+        .current_dir(archive.path())
+        .env("HOME", home.path())
+        .env("NO_COLOR", "1")
+        .args(["--json", "app", "install"])
+        .output()
+        .expect("failed to run apw app install from archive fixture");
+    let install = CommandOutput {
+        status: output.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+    };
+    assert_eq!(install.status, 0, "{install:#?}");
+
+    let payload = parse_success(&install);
+    assert_eq!(payload["payload"]["status"], "installed");
+    assert_eq!(payload["payload"]["version"], "2.0.0");
+    assert!(home
+        .path()
+        .join(".apw/native-app/installed/APW.app/Contents/MacOS/APW")
+        .exists());
 }
 
 #[test]

--- a/scripts/build-apw-release.sh
+++ b/scripts/build-apw-release.sh
@@ -5,6 +5,7 @@ print_help() {
   cat <<'EOF'
 Usage: ./scripts/build-apw-release.sh [--install|--no-install] [--brew-smoke|--no-brew-smoke]
                                     [--install-dir /usr/local/bin] [--skip-version]
+                                    [--archive-smoke|--no-archive-smoke]
 
 Options:
   --install              install apw to --install-dir (defaults to /usr/local/bin)
@@ -13,6 +14,8 @@ Options:
   --brew-smoke           run local Homebrew source smoke test
   --no-brew-smoke        skip Homebrew smoke test (default)
   --skip-version         skip --version and status checks
+  --archive-smoke        smoke test the generated release archive (default)
+  --no-archive-smoke     skip release archive smoke test
   -h, --help             show this help message
 
 Examples:
@@ -25,10 +28,19 @@ EOF
 ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN_PATH="$ROOT_DIR/rust/target/release/apw"
 CARGO_MANIFEST="$ROOT_DIR/rust/Cargo.toml"
+APP_BUNDLE_PATH="$ROOT_DIR/native-app/dist/APW.app"
+VERSION="$(awk -F ' = ' '/^version = / {gsub(/"/, "", $2); print $2; exit}' "$CARGO_MANIFEST")"
+ARCHIVE_PATH="$ROOT_DIR/dist/apw-macos-v${VERSION}.tar.gz"
 INSTALL_BIN=0
 INSTALL_DIR="/usr/local/bin"
 BREW_SMOKE=0
 SKIP_VERSION_CHECK=0
+ARCHIVE_SMOKE=1
+
+if [[ -z "$VERSION" ]]; then
+  echo "Unable to read version from $CARGO_MANIFEST"
+  exit 1
+fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -56,6 +68,12 @@ while [[ $# -gt 0 ]]; do
     --skip-version)
       SKIP_VERSION_CHECK=1
       ;;
+    --archive-smoke)
+      ARCHIVE_SMOKE=1
+      ;;
+    --no-archive-smoke)
+      ARCHIVE_SMOKE=0
+      ;;
     -h|--help)
       print_help
       exit 0
@@ -79,22 +97,49 @@ if [ ! -f "$CARGO_MANIFEST" ]; then
   exit 1
 fi
 
-printf '\n[1/4] Building APW app bundle...\n'
+printf '\n[1/5] Building APW app bundle...\n'
 cd "$ROOT_DIR"
 "$ROOT_DIR/scripts/build-native-app.sh"
 
-printf '\n[2/4] Building release binary...\n'
+printf '\n[2/5] Building release binary...\n'
 cd "$ROOT_DIR"
 cargo build --manifest-path "$CARGO_MANIFEST" --release
 
+printf '\n[3/5] Packaging release archive...\n'
+rm -rf "$ROOT_DIR/dist/apw" "$ROOT_DIR/dist/APW.app"
+mkdir -p "$ROOT_DIR/dist"
+cp "$BIN_PATH" "$ROOT_DIR/dist/apw"
+cp -R "$APP_BUNDLE_PATH" "$ROOT_DIR/dist/APW.app"
+tar -czf "$ARCHIVE_PATH" -C "$ROOT_DIR/dist" apw APW.app
+rm -rf "$ROOT_DIR/dist/apw" "$ROOT_DIR/dist/APW.app"
+echo "Created: $ARCHIVE_PATH"
+
 if [ "$SKIP_VERSION_CHECK" -ne 1 ]; then
-  printf '\n[3/4] Validating binary health...\n'
+  printf '\n[4/5] Validating binary health...\n'
   "$BIN_PATH" --version
   "$BIN_PATH" status --json
 fi
 
+if [ "$ARCHIVE_SMOKE" -eq 1 ]; then
+  printf '\n[5/5] Validating release archive smoke...\n'
+  smoke_dir="$(mktemp -d)"
+  smoke_home="$(mktemp -d)"
+  cleanup_smoke() {
+    rm -rf "$smoke_dir" "$smoke_home"
+  }
+  trap cleanup_smoke EXIT
+  tar -xzf "$ARCHIVE_PATH" -C "$smoke_dir"
+  test -x "$smoke_dir/apw"
+  test -x "$smoke_dir/APW.app/Contents/MacOS/APW"
+  HOME="$smoke_home" "$smoke_dir/apw" --version
+  HOME="$smoke_home" "$smoke_dir/apw" status --json
+  HOME="$smoke_home" "$smoke_dir/apw" app install
+  trap - EXIT
+  cleanup_smoke
+fi
+
 if [ "$INSTALL_BIN" -eq 1 ]; then
-  printf '\n[4/4] Installing to %s...\n' "$INSTALL_DIR"
+  printf '\nInstalling to %s...\n' "$INSTALL_DIR"
   if [ ! -d "$INSTALL_DIR" ]; then
     echo "Install directory does not exist: $INSTALL_DIR"
     exit 1
@@ -106,7 +151,7 @@ if [ "$INSTALL_BIN" -eq 1 ]; then
 fi
 
 if [ "$BREW_SMOKE" -eq 1 ]; then
-  printf '\n[5/5] Running Homebrew source smoke test...\n'
+  printf '\nRunning Homebrew source smoke test...\n'
   if [ -f "$ROOT_DIR/packaging/homebrew/install-from-source.sh" ]; then
     "$ROOT_DIR/packaging/homebrew/install-from-source.sh"
   else

--- a/scripts/release-bootstrap.sh
+++ b/scripts/release-bootstrap.sh
@@ -216,13 +216,44 @@ publish_release_asset() {
 build_release_artifact() {
   local version="$1"
   local artifact_path="$ROOT_DIR/dist/apw-macos-v${version}.tar.gz"
+  local app_bundle="$ROOT_DIR/native-app/dist/APW.app"
   mkdir -p "$ROOT_DIR/dist"
 
+  if [[ ! -d "$app_bundle" ]]; then
+    echo "Expected APW app bundle not found: $app_bundle"
+    echo "Run ./scripts/build-native-app.sh before packaging the release artifact."
+    exit 1
+  fi
+
+  rm -rf "$ROOT_DIR/dist/apw" "$ROOT_DIR/dist/APW.app"
   cp "$BIN_PATH" "$ROOT_DIR/dist/apw"
-  tar -czf "$artifact_path" -C "$ROOT_DIR/dist" apw
-  rm "$ROOT_DIR/dist/apw"
+  cp -R "$app_bundle" "$ROOT_DIR/dist/APW.app"
+  tar -czf "$artifact_path" -C "$ROOT_DIR/dist" apw APW.app
+  rm -rf "$ROOT_DIR/dist/apw" "$ROOT_DIR/dist/APW.app"
 
   echo "$artifact_path"
+}
+
+smoke_release_artifact() {
+  local artifact="$1"
+  local smoke_dir
+  local smoke_home
+
+  smoke_dir="$(mktemp -d)"
+  smoke_home="$(mktemp -d)"
+  cleanup_release_smoke() {
+    rm -rf "$smoke_dir" "$smoke_home"
+  }
+  trap cleanup_release_smoke EXIT
+
+  tar -xzf "$artifact" -C "$smoke_dir"
+  test -x "$smoke_dir/apw"
+  test -x "$smoke_dir/APW.app/Contents/MacOS/APW"
+  HOME="$smoke_home" "$smoke_dir/apw" --version
+  HOME="$smoke_home" "$smoke_dir/apw" status --json
+  HOME="$smoke_home" "$smoke_dir/apw" app install
+  trap - EXIT
+  cleanup_release_smoke
 }
 
 normalize_tag() {
@@ -260,7 +291,7 @@ if [[ -n "$highest_existing_version" ]] && ! version_advances_history "${TAG#v}"
   exit 1
 fi
 
-printf '\n[1/8] Verifying version sync across release surfaces...\n'
+printf '\n[1/9] Verifying version sync across release surfaces...\n'
 bash "$VERIFY_SCRIPT" "$CARGO_MANIFEST" \
   "$ROOT_DIR/rust/src/cli.rs" \
   "$ROOT_DIR/rust/src/types.rs" \
@@ -269,7 +300,7 @@ bash "$VERIFY_SCRIPT" "$CARGO_MANIFEST" \
   "$ROOT_DIR/docs/INSTALLATION.md" \
   "$ROOT_DIR/docs/MIGRATION_AND_PARITY.md"
 
-printf '\n[2/8] Running release gates...\n'
+printf '\n[2/9] Running release gates...\n'
 cargo fmt --manifest-path "$CARGO_MANIFEST" -- --check
 cargo clippy --manifest-path "$CARGO_MANIFEST" --all-targets -- -D warnings
 if [[ "$SKIP_TESTS" -eq 0 ]]; then
@@ -278,15 +309,18 @@ if [[ "$SKIP_TESTS" -eq 0 ]]; then
   cargo test --manifest-path "$CARGO_MANIFEST" --test security_regressions
 fi
 
-printf '\n[3/8] Building release binary...\n'
+printf '\n[3/9] Building APW app bundle...\n'
+./scripts/build-native-app.sh
+
+printf '\n[4/9] Building release binary...\n'
 cargo build --manifest-path "$CARGO_MANIFEST" --release
 
-printf '\n[4/8] Health check release binary...\n'
+printf '\n[5/9] Health check release binary...\n'
 "$BIN_PATH" --version
 "$BIN_PATH" status --json
 
 if [[ "$HOST_SMOKE" -eq 1 ]]; then
-  printf '\n[5/8] Running browser host smoke...\n'
+  printf '\n[6/9] Running browser host smoke...\n'
   if [[ -n "$HOST_SMOKE_OTP_DOMAIN" ]]; then
     "$ROOT_DIR/scripts/browser-host-smoke.sh" \
       --bin "$BIN_PATH" \
@@ -299,14 +333,14 @@ if [[ "$HOST_SMOKE" -eq 1 ]]; then
   fi
 fi
 
-printf '\n[6/8] Creating tag %s...\n' "$TAG"
+printf '\n[7/9] Creating tag %s...\n' "$TAG"
 git tag -a "$TAG" -m "chore: release ${TAG}"
 VERSION="${TAG#v}"
 formula_url="$(extract_formula_url)"
 validate_formula_url_matches_tag "$formula_url" "$TAG"
 
 if [[ "$PUSH_TAG" -eq 1 ]]; then
-  printf '\n[7/8] Pushing tag %s...\n' "$TAG"
+  printf '\n[8/9] Pushing tag %s...\n' "$TAG"
   git push origin "$TAG"
   if [[ "$BREW_SMOKE" -eq 1 ]]; then
     if ! command -v brew >/dev/null 2>&1; then
@@ -333,9 +367,10 @@ else
 fi
 
 if [[ "$PUBLISH_RELEASE" -eq 1 ]]; then
-  printf '\n[8/8] Building release tarball and publishing assets for %s...\n' "$TAG"
+  printf '\n[9/9] Building release tarball and publishing assets for %s...\n' "$TAG"
   ARTIFACT_PATH="$(build_release_artifact "$VERSION")"
   echo "Created release artifact: $ARTIFACT_PATH"
+  smoke_release_artifact "$ARTIFACT_PATH"
   publish_release_asset "$ARTIFACT_PATH" "$TAG"
 fi
 


### PR DESCRIPTION
## Summary
- include root-level `apw` and `APW.app/` in macOS release archives
- make `apw app install` discover an app bundle beside the extracted CLI
- add release archive smoke coverage for `apw --version`, `apw status --json`, and `apw app install`

Closes #21

## Validation
- `bash -n scripts/build-apw-release.sh scripts/release-bootstrap.sh`
- `cargo fmt --manifest-path rust/Cargo.toml -- --check`
- `cargo test --manifest-path rust/Cargo.toml --test native_app_e2e app_install_finds_release_archive_sibling_bundle -- --nocapture`
- `./scripts/build-apw-release.sh --no-brew-smoke`
- `tar -tzf dist/apw-macos-v2.0.0.tar.gz`
- `git diff --check`

## Notes
- Full `native_app_e2e` stalled in broader socket-backed tests; the new archive regression and archive smoke passed.
