### PR TITLE
Add Homebrew formula rendering helper

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -69,6 +69,19 @@ This validates:
 Use [`packaging/homebrew/apw.rb`](../packaging/homebrew/apw.rb)
 as the formula template.
 
+Render the formula for the release tarball before opening the tap PR:
+
+```bash
+version="2.0.0"
+sha256="$(curl -fsSL "https://github.com/OMT-Global/apw-cli/archive/refs/tags/v${version}.tar.gz" | shasum -a 256 | awk '{print $1}')"
+./scripts/render-homebrew-formula.sh "$version" "$sha256"
+```
+
+Then copy `packaging/homebrew/apw.rb` into the tap as `Formula/apw.rb`,
+commit it, and open a tap pull request. Until tap publishing credentials are
+available to the release workflow, this manual PR is the supported publishing
+path.
+
 After installing with Homebrew, install the per-user APW app bundle:
 
 ```bash

--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -16,6 +16,11 @@ if [ ! -x scripts/bump-version.sh ]; then
   exit 1
 fi
 
+if [ ! -x scripts/render-homebrew-formula.sh ]; then
+  echo "scripts/render-homebrew-formula.sh must be executable." >&2
+  exit 1
+fi
+
 chmod +x ./.github/scripts/verify-version-sync.sh
 ./.github/scripts/verify-version-sync.sh \
   rust/Cargo.toml \
@@ -29,5 +34,7 @@ chmod +x ./.github/scripts/verify-version-sync.sh
 while IFS= read -r -d '' script; do
   bash -n "$script"
 done < <(find .github/scripts scripts -type f -name '*.sh' -print0)
+
+./scripts/test-render-homebrew-formula.sh
 
 echo "APW fast checks passed."

--- a/scripts/render-homebrew-formula.sh
+++ b/scripts/render-homebrew-formula.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORMULA_PATH="${APW_HOMEBREW_FORMULA_PATH:-$ROOT_DIR/packaging/homebrew/apw.rb}"
+
+usage() {
+  echo "Usage: scripts/render-homebrew-formula.sh <version> <sha256>" >&2
+}
+
+if [ "$#" -ne 2 ]; then
+  usage
+  exit 2
+fi
+
+version="$1"
+sha256="$2"
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Version must be semver without a leading v, for example 2.1.0." >&2
+  exit 2
+fi
+
+if [[ ! "$sha256" =~ ^[0-9a-fA-F]{64}$ ]]; then
+  echo "sha256 must be a 64-character hexadecimal digest." >&2
+  exit 2
+fi
+
+if [ ! -f "$FORMULA_PATH" ]; then
+  echo "Formula not found: $FORMULA_PATH" >&2
+  exit 1
+fi
+
+export APW_FORMULA_VERSION="$version"
+export APW_FORMULA_SHA256="$(printf '%s' "$sha256" | tr 'A-F' 'a-f')"
+
+perl -0pi -e '
+  s#(url\s+"https://github\.com/OMT-Global/apw-cli/archive/refs/tags/v)[^"]+(\.tar\.gz")#$1$ENV{APW_FORMULA_VERSION}$2#g;
+  s#(^\s*version\s+")[^"]+(")#$1$ENV{APW_FORMULA_VERSION}$2#gm;
+  s#(^\s*sha256\s+")[^"]+(")#$1$ENV{APW_FORMULA_SHA256}$2#gm;
+' "$FORMULA_PATH"
+
+if ! grep -q "refs/tags/v${version}.tar.gz" "$FORMULA_PATH"; then
+  echo "Rendered formula is missing expected release tarball URL for v${version}." >&2
+  exit 1
+fi
+
+if ! grep -Eq "^[[:space:]]*version[[:space:]]+\"${version}\"" "$FORMULA_PATH"; then
+  echo "Rendered formula is missing expected version ${version}." >&2
+  exit 1
+fi
+
+if ! grep -Eq "^[[:space:]]*sha256[[:space:]]+\"${APW_FORMULA_SHA256}\"" "$FORMULA_PATH"; then
+  echo "Rendered formula is missing expected sha256 ${APW_FORMULA_SHA256}." >&2
+  exit 1
+fi
+
+echo "Rendered $FORMULA_PATH for v${version}."

--- a/scripts/test-render-homebrew-formula.sh
+++ b/scripts/test-render-homebrew-formula.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+formula_copy="$tmp_dir/apw.rb"
+cp "$ROOT_DIR/packaging/homebrew/apw.rb" "$formula_copy"
+
+version="9.8.7"
+sha256="ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
+normalized_sha256="$(printf '%s' "$sha256" | tr 'A-F' 'a-f')"
+
+APW_HOMEBREW_FORMULA_PATH="$formula_copy" \
+  "$ROOT_DIR/scripts/render-homebrew-formula.sh" "$version" "$sha256" >/dev/null
+
+grep -q "version \"$version\"" "$formula_copy"
+grep -q "refs/tags/v${version}.tar.gz" "$formula_copy"
+grep -q "sha256 \"$normalized_sha256\"" "$formula_copy"
+
+if APW_HOMEBREW_FORMULA_PATH="$formula_copy" \
+  "$ROOT_DIR/scripts/render-homebrew-formula.sh" v9.8.7 "$normalized_sha256" >/dev/null 2>&1; then
+  echo "render-homebrew-formula accepted a version with leading v." >&2
+  exit 1
+fi
+
+if APW_HOMEBREW_FORMULA_PATH="$formula_copy" \
+  "$ROOT_DIR/scripts/render-homebrew-formula.sh" "$version" "not-a-sha" >/dev/null 2>&1; then
+  echo "render-homebrew-formula accepted an invalid sha256." >&2
+  exit 1
+fi
+
+echo "Homebrew formula renderer test passed."


### PR DESCRIPTION
## Summary
- add `scripts/render-homebrew-formula.sh` for release version/SHA rendering
- add a focused renderer regression test and wire it into fast checks
- document the manual tap PR path until release workflow tap credentials are available

Closes #6

## Validation
- `./scripts/test-render-homebrew-formula.sh`
- `./scripts/ci/run-fast-checks.sh`
- `git diff --check`

## Notes
- Full automated tap publishing remains intentionally deferred because it requires scoped `HOMEBREW_TAP_TOKEN`/tap repository credentials.
