### PR TITLE
Validate external provider fallback paths

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -107,6 +107,21 @@ Healthy v2 bootstrap state usually looks like:
 apw login https://example.com
 ```
 
+### External password manager fallback
+
+When the native app broker cannot return a credential, APW can fall back to a
+configured external password manager CLI provider. The fallback executable path
+is security-sensitive and is validated before APW invokes it.
+
+`fallbackProviderPath` must follow these rules:
+
+- Use an absolute path. Relative paths and `~` expansion are rejected.
+- Resolve through `realpath`/canonicalization. Symlinks are followed and the
+  resolved executable is the file APW invokes.
+- Resolve to a regular file owned by the current user.
+- Use `0755` permissions or more restrictive permissions. Group-writable,
+  world-writable, and special-mode executables are rejected.
+
 ## Diagnostics
 
 ### Machine-readable status

--- a/rust/src/native_app.rs
+++ b/rust/src/native_app.rs
@@ -1,7 +1,7 @@
 use crate::error::{APWError, Result};
 use crate::logging;
 use crate::types::{ExternalFallbackProvider, Status, MAX_MESSAGE_BYTES, VERSION};
-use crate::utils::read_config_file_or_empty;
+use crate::utils::{read_config_file, validate_external_provider_path};
 use serde_json::{json, Value};
 use std::env;
 use std::fs;
@@ -698,7 +698,11 @@ fn native_app_request(intent: &str, url: &str) -> Result<Value> {
 }
 
 fn external_provider_login(url: &str) -> Result<Option<Value>> {
-    let config = read_config_file_or_empty();
+    let config = match read_config_file() {
+        Ok(config) => config,
+        Err(error) if error.message.starts_with("No config file at ") => return Ok(None),
+        Err(error) => return Err(error),
+    };
     let Some(provider) = config.fallback_provider else {
         return Ok(None);
     };
@@ -711,16 +715,7 @@ fn external_provider_login(url: &str) -> Result<Option<Value>> {
             ),
         ));
     };
-    let provider_path = PathBuf::from(provider_path);
-    if !provider_path.is_absolute() {
-        return Err(APWError::new(
-            Status::InvalidConfig,
-            format!(
-                "Fallback provider `{}` must use an absolute executable path.",
-                provider.as_str()
-            ),
-        ));
-    }
+    let provider_path = validate_external_provider_path(provider, provider_path)?;
 
     let host = url::Url::parse(url)
         .map_err(|_| APWError::new(Status::InvalidParam, "Invalid URL for external fallback."))?

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -1,8 +1,8 @@
 use crate::error::{APWError, Result};
 use crate::secrets::{delete_shared_key, read_shared_key, supports_keychain, write_shared_key};
 use crate::types::{
-    normalize_status, APWConfig, APWConfigV1, APWRuntimeConfig, RuntimeMode, SecretSource,
-    DEFAULT_HOST, DEFAULT_PORT,
+    normalize_status, APWConfig, APWConfigV1, APWRuntimeConfig, ExternalFallbackProvider,
+    RuntimeMode, SecretSource, DEFAULT_HOST, DEFAULT_PORT,
 };
 use base64::{engine::general_purpose, Engine as _};
 use chrono::{TimeZone, Utc};
@@ -14,6 +14,7 @@ use sha2::{Digest, Sha256};
 use std::env;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
+use std::os::unix::fs::MetadataExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
@@ -23,6 +24,7 @@ const CONFIG_DIRECTORY_MODE: u32 = 0o700;
 const CONFIG_FILE_MODE: u32 = 0o600;
 const CONFIG_SCHEMA: i32 = 1;
 const MAX_CONFIG_SIZE_BYTES: usize = 10 * 1024;
+const EXTERNAL_PROVIDER_MAX_MODE: u32 = 0o755;
 
 #[derive(Debug, Clone)]
 pub struct ConfigReadOptions {
@@ -168,7 +170,7 @@ fn read_config_file_or_null() -> Result<APWConfigV1> {
                 "Invalid config host or port.",
             ));
         }
-        return Ok(v1);
+        return validate_external_provider_config(v1);
     }
 
     let legacy = serde_json::from_value::<APWConfig>(parsed).map_err(|_| {
@@ -179,6 +181,24 @@ fn read_config_file_or_null() -> Result<APWConfigV1> {
     })?;
 
     Ok(normalize_legacy_config(legacy))
+}
+
+fn validate_external_provider_config(mut config: APWConfigV1) -> Result<APWConfigV1> {
+    let Some(provider) = config.fallback_provider else {
+        return Ok(config);
+    };
+    let Some(provider_path) = config.fallback_provider_path.as_deref() else {
+        return Err(APWError::new(
+            crate::types::Status::InvalidConfig,
+            format!(
+                "Fallback provider `{}` requires an absolute `fallbackProviderPath`.",
+                provider.as_str()
+            ),
+        ));
+    };
+    let resolved_path = validate_external_provider_path(provider, provider_path)?;
+    config.fallback_provider_path = Some(resolved_path.display().to_string());
+    Ok(config)
 }
 
 fn resolve_secret_source(raw: &APWConfigV1) -> SecretSource {
@@ -225,8 +245,85 @@ fn normalize_legacy_config(raw: APWConfig) -> APWConfigV1 {
     }
 }
 
-fn read_config_file() -> Result<APWConfigV1> {
+pub fn read_config_file() -> Result<APWConfigV1> {
     read_config_file_or_null()
+}
+
+pub fn validate_external_provider_path(
+    provider: ExternalFallbackProvider,
+    provider_path: &str,
+) -> Result<PathBuf> {
+    let raw_path = PathBuf::from(provider_path);
+    if provider_path.starts_with('~') || !raw_path.is_absolute() {
+        return Err(APWError::new(
+            crate::types::Status::InvalidConfig,
+            format!(
+                "Fallback provider `{}` must use an absolute executable path; `~` and relative paths are not allowed.",
+                provider.as_str()
+            ),
+        ));
+    }
+
+    let resolved_path = raw_path.canonicalize().map_err(|error| {
+        APWError::new(
+            crate::types::Status::InvalidConfig,
+            format!(
+                "Fallback provider `{}` path {} could not be resolved: {error}",
+                provider.as_str(),
+                raw_path.display()
+            ),
+        )
+    })?;
+
+    let metadata = fs::metadata(&resolved_path).map_err(|error| {
+        APWError::new(
+            crate::types::Status::InvalidConfig,
+            format!(
+                "Fallback provider `{}` path {} could not be inspected: {error}",
+                provider.as_str(),
+                resolved_path.display()
+            ),
+        )
+    })?;
+    if !metadata.is_file() {
+        return Err(APWError::new(
+            crate::types::Status::InvalidConfig,
+            format!(
+                "Fallback provider `{}` path {} must resolve to a regular file.",
+                provider.as_str(),
+                resolved_path.display()
+            ),
+        ));
+    }
+
+    // SAFETY: `geteuid` reads the effective uid for the current process and has
+    // no memory-safety preconditions.
+    let current_uid = unsafe { libc::geteuid() };
+    if metadata.uid() != current_uid {
+        return Err(APWError::new(
+            crate::types::Status::InvalidConfig,
+            format!(
+                "Fallback provider `{}` path {} must be owned by the current user.",
+                provider.as_str(),
+                resolved_path.display()
+            ),
+        ));
+    }
+
+    let mode = metadata.permissions().mode() & 0o7777;
+    if mode & !EXTERNAL_PROVIDER_MAX_MODE != 0 {
+        return Err(APWError::new(
+            crate::types::Status::InvalidConfig,
+            format!(
+                "Fallback provider `{}` path {} has insecure permissions {:04o}; use 0755 or more restrictive permissions.",
+                provider.as_str(),
+                resolved_path.display(),
+                mode
+            ),
+        ));
+    }
+
+    Ok(resolved_path)
 }
 
 #[allow(dead_code)]

--- a/rust/tests/security_regressions.rs
+++ b/rust/tests/security_regressions.rs
@@ -3,6 +3,8 @@ use serde_json::Value;
 use serial_test::serial;
 use std::env;
 use std::fs;
+use std::os::unix::fs::symlink;
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
@@ -67,6 +69,78 @@ fn write_launch_failure_config(home: &Path, last_launch_error: &str) {
         serde_json::to_vec_pretty(&config).expect("failed to serialize config"),
     )
     .expect("failed to write config");
+}
+
+fn write_fallback_provider_config(home: &Path, provider_path: &str) {
+    let config = serde_json::json!({
+        "schema": 1,
+        "port": 10_000,
+        "host": "127.0.0.1",
+        "username": "demo",
+        "sharedKey": "demo-shared-key",
+        "runtimeMode": "auto",
+        "secretSource": "file",
+        "fallbackProvider": "bitwarden",
+        "fallbackProviderPath": provider_path,
+        "createdAt": Utc::now().to_rfc3339(),
+    });
+
+    fs::create_dir_all(home.join(".apw")).expect("failed to create config directory");
+    fs::write(
+        home.join(".apw/config.json"),
+        serde_json::to_vec_pretty(&config).expect("failed to serialize config"),
+    )
+    .expect("failed to write config");
+}
+
+fn write_bitwarden_provider(path: &Path) {
+    fs::write(
+        path,
+        r#"#!/usr/bin/env python3
+import json
+import sys
+
+if sys.argv[1:] == ["list", "items", "--search", "vault.example.com"]:
+    print(json.dumps([
+      {
+        "login": {
+          "username": "alice@example.com",
+          "password": "secret-bitwarden",
+          "uris": [{"uri": "https://vault.example.com/login"}]
+        }
+      }
+    ]))
+else:
+    raise SystemExit(1)
+"#,
+    )
+    .expect("failed to write fallback provider");
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755))
+        .expect("failed to chmod fallback provider");
+}
+
+fn install_native_app_no_results(home: &Path) {
+    let executable = home
+        .join(".apw")
+        .join("native-app")
+        .join("installed")
+        .join("APW.app")
+        .join("Contents")
+        .join("MacOS")
+        .join("APW");
+    fs::create_dir_all(executable.parent().expect("missing executable parent"))
+        .expect("failed to create native app bundle");
+    fs::write(
+        &executable,
+        r#"#!/usr/bin/env python3
+import json
+
+print(json.dumps({"ok": False, "code": 3, "error": "no credential"}))
+"#,
+    )
+    .expect("failed to write native app executable");
+    fs::set_permissions(&executable, fs::Permissions::from_mode(0o755))
+        .expect("failed to chmod native app executable");
 }
 
 #[test]
@@ -141,6 +215,106 @@ fn status_json_has_stable_shape() {
         assert_eq!(output["payload"]["session"]["authenticated"], false);
         assert!(output["payload"]["session"]["createdAt"].is_string());
         assert!(output["payload"]["session"]["expired"].is_boolean());
+    });
+}
+
+#[test]
+#[serial]
+fn login_rejects_relative_external_provider_path() {
+    with_temp_home(|home| {
+        install_native_app_no_results(home);
+        write_fallback_provider_config(home, "bw");
+
+        let (status, stdout, stderr) =
+            run_command(home, &["--json", "login", "https://vault.example.com"]);
+
+        assert_eq!(
+            status, 102,
+            "status={status}, stdout={stdout}, stderr={stderr}"
+        );
+        let output = parse_json_output(&stderr);
+        assert_eq!(output["code"], 102);
+        let error = output["error"].as_str().unwrap_or_default();
+        assert!(error.contains("absolute executable path"));
+        assert!(error.contains("relative paths are not allowed"));
+    });
+}
+
+#[test]
+#[serial]
+fn login_rejects_tilde_external_provider_path() {
+    with_temp_home(|home| {
+        install_native_app_no_results(home);
+        write_fallback_provider_config(home, "~/bin/bw");
+
+        let (status, stdout, stderr) =
+            run_command(home, &["--json", "login", "https://vault.example.com"]);
+
+        assert_eq!(
+            status, 102,
+            "status={status}, stdout={stdout}, stderr={stderr}"
+        );
+        let output = parse_json_output(&stderr);
+        assert_eq!(output["code"], 102);
+        let error = output["error"].as_str().unwrap_or_default();
+        assert!(error.contains("absolute executable path"));
+        assert!(error.contains("`~`"));
+    });
+}
+
+#[test]
+#[serial]
+fn login_rejects_world_writable_external_provider_path() {
+    with_temp_home(|home| {
+        install_native_app_no_results(home);
+        let provider_dir = TempDir::new().expect("failed to create provider tempdir");
+        let provider_path = provider_dir.path().join("bw");
+        write_bitwarden_provider(&provider_path);
+        fs::set_permissions(&provider_path, fs::Permissions::from_mode(0o777))
+            .expect("failed to chmod fallback provider");
+        write_fallback_provider_config(home, &provider_path.display().to_string());
+
+        let (status, stdout, stderr) =
+            run_command(home, &["--json", "login", "https://vault.example.com"]);
+
+        assert_eq!(
+            status, 102,
+            "status={status}, stdout={stdout}, stderr={stderr}"
+        );
+        let output = parse_json_output(&stderr);
+        assert_eq!(output["code"], 102);
+        let error = output["error"].as_str().unwrap_or_default();
+        assert!(error.contains("insecure permissions"));
+        assert!(error.contains("0755 or more restrictive"));
+    });
+}
+
+#[test]
+#[serial]
+fn login_rejects_external_provider_symlink_to_insecure_target() {
+    with_temp_home(|home| {
+        install_native_app_no_results(home);
+        let provider_dir = TempDir::new().expect("failed to create provider tempdir");
+        let provider_path = provider_dir.path().join("bw-real");
+        let provider_link = provider_dir.path().join("bw-link");
+        write_bitwarden_provider(&provider_path);
+        fs::set_permissions(&provider_path, fs::Permissions::from_mode(0o777))
+            .expect("failed to chmod fallback provider");
+        symlink(&provider_path, &provider_link).expect("failed to create provider symlink");
+        write_fallback_provider_config(home, &provider_link.display().to_string());
+
+        let (status, stdout, stderr) =
+            run_command(home, &["--json", "login", "https://vault.example.com"]);
+
+        assert_eq!(
+            status, 102,
+            "status={status}, stdout={stdout}, stderr={stderr}"
+        );
+        let output = parse_json_output(&stderr);
+        assert_eq!(output["code"], 102);
+        let error = output["error"].as_str().unwrap_or_default();
+        assert!(error.contains(&provider_path.display().to_string()));
+        assert!(error.contains("insecure permissions"));
     });
 }
 


### PR DESCRIPTION
## Summary
- validate external fallback provider paths at config read/invocation time
- reject relative and `~` paths, canonicalize symlinks, require current-user owned regular files
- reject group/world/special writable provider executables and document the rules

Closes #1

## Validation
- `cargo fmt --manifest-path rust/Cargo.toml -- --check`
- `cargo test --manifest-path rust/Cargo.toml --test security_regressions`
- `cargo test --manifest-path rust/Cargo.toml native_app::tests::login_ -- --nocapture`
- `git diff --check`

## Notes
- Commit was created with `commit.gpgsign=false` after noninteractive Sigstore signing failed locally.
