### PR TITLE
test(native-app): avoid chmodding timeout socket

### DIFF
--- a/rust/src/native_app.rs
+++ b/rust/src/native_app.rs
@@ -1419,9 +1419,19 @@ mod tests {
     use crate::types::APWConfigV1;
     use serial_test::serial;
     use std::os::unix::net::UnixListener;
+    use std::path::Path;
     use tempfile::TempDir;
 
     const TEST_EXTERNAL_FALLBACK_TIMEOUT_MS: u64 = 500;
+
+    fn bind_restrictive_socket(path: &Path) -> UnixListener {
+        let previous_umask = unsafe { libc::umask(0o177) };
+        let listener = UnixListener::bind(path);
+        unsafe {
+            libc::umask(previous_umask);
+        }
+        listener.unwrap()
+    }
 
     fn with_temp_home<F, R>(run: F) -> R
     where
@@ -2069,8 +2079,7 @@ print(json.dumps({
         with_temp_home(|| {
             ensure_runtime_dir().unwrap();
             let socket_path = native_app_socket_path();
-            let listener = UnixListener::bind(&socket_path).unwrap();
-            set_permissions(&socket_path, NATIVE_APP_FILE_MODE).unwrap();
+            let listener = bind_restrictive_socket(&socket_path);
 
             let handle = std::thread::spawn(move || {
                 if let Ok((stream, _addr)) = listener.accept() {


### PR DESCRIPTION
## Summary
- Avoid chmodding the Unix socket path in the native-app timeout regression test.
- Bind the test socket under a temporary restrictive umask so the socket is created with owner-only permissions on platforms like macOS where chmod on sockets returns EPERM.
- Keep the test focused on the intended hung-broker timeout behavior.

Closes #41

## Testing
- `PKG_CONFIG_PATH=/home/linuxbrew/.linuxbrew/lib/pkgconfig cargo test native_app::tests`
- `PKG_CONFIG_PATH=/home/linuxbrew/.linuxbrew/lib/pkgconfig cargo test native_app::tests::socket_request_times_out_when_broker_does_not_reply`
- `cargo fmt --check`

## Merge Automation
Auto-merge is enabled with squash merge. The PR is ready for review and remains blocked until the required review approval is satisfied.

## AI assistance disclosure
This PR was prepared with AI assistance and manually verified with the commands above.
