### PR TITLE
Bound subprocess execution in doctor CI + direct-exec, provision macOS OpenSSL

### DIFF
--- a/.github/workflows/extended-validation.yml
+++ b/.github/workflows/extended-validation.yml
@@ -99,6 +99,27 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Provision OpenSSL and pkg-config for openssl-sys
+        # Issue #40: the openssl-sys build script needs pkg-config to find a
+        # system OpenSSL on macOS. The xcode runner image does not ship
+        # pkg-config by default, so we install it (and OpenSSL) via brew and
+        # export the discovery env vars for subsequent steps.
+        run: |
+          set -euo pipefail
+          if ! command -v brew >/dev/null 2>&1; then
+            echo "Homebrew is required on the macOS runner to provision OpenSSL." >&2
+            exit 1
+          fi
+          brew list pkg-config >/dev/null 2>&1 || brew install pkg-config
+          brew list openssl@3 >/dev/null 2>&1 || brew install openssl@3
+          OPENSSL_PREFIX="$(brew --prefix openssl@3)"
+          {
+            echo "OPENSSL_DIR=$OPENSSL_PREFIX"
+            echo "OPENSSL_INCLUDE_DIR=$OPENSSL_PREFIX/include"
+            echo "OPENSSL_LIB_DIR=$OPENSSL_PREFIX/lib"
+            echo "PKG_CONFIG_PATH=$OPENSSL_PREFIX/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+          } >> "$GITHUB_ENV"
+
       - name: Run extended validation
         run: bash scripts/ci/run-extended-validation.sh
 

--- a/docs/SECURITY_POSTURE_AND_TESTING.md
+++ b/docs/SECURITY_POSTURE_AND_TESTING.md
@@ -39,8 +39,15 @@ Release reference version: `v2.0.0`
 - native app UNIX-socket requests use a `3s` read/write timeout
 - a hung broker socket returns a non-zero `CommunicationTimeout` error instead
   of blocking the CLI indefinitely
-- direct executable fallback responses are still bounded by the same maximum
-  response size before JSON decoding
+- direct executable fallback runs the APW app bundle under a `5s` wall-clock
+  timeout, reads at most the configured maximum response size from each of
+  stdout and stderr via bounded pipe reads, and terminates the child (process
+  group) on timeout so a hung or runaway fallback cannot block or exhaust CLI
+  memory
+- `apw doctor` CI diagnostics run external tool probes (`xcodebuild`, `cargo`,
+  `detect-secrets`, `security find-identity`) under the same bounded-read
+  helper with a `3s` per-probe timeout, so a misconfigured shim does not hang
+  the doctor command
 - timed-out requests do not cache or persist partially returned credentials
 
 ## Required release gates

--- a/rust/src/native_app.rs
+++ b/rust/src/native_app.rs
@@ -25,6 +25,9 @@ const NATIVE_APP_FILE_MODE: u32 = 0o600;
 const MAX_BROKER_BYTES: usize = MAX_MESSAGE_BYTES;
 const MAX_BROKER_LOG_BYTES: u64 = 10 * 1024 * 1024;
 const NATIVE_APP_SOCKET_TIMEOUT_MS: u64 = 3_000;
+const NATIVE_APP_DIRECT_EXEC_TIMEOUT_MS: u64 = 5_000;
+const DOCTOR_PROBE_TIMEOUT_MS: u64 = 3_000;
+const BOUNDED_COMMAND_POLL_MS: u64 = 20;
 const EXTERNAL_PROVIDER_DEFAULT_TIMEOUT_MS: u64 = 5_000;
 const EXTERNAL_PROVIDER_DEFAULT_MAX_INVOCATIONS: u32 = 10;
 const EXTERNAL_PROVIDER_POLL_MS: u64 = 20;
@@ -239,12 +242,154 @@ fn load_status_file() -> Option<Value> {
     serde_json::from_str(&fs::read_to_string(native_app_status_path()).ok()?).ok()
 }
 
-fn command_output(command: &str, args: &[&str]) -> std::io::Result<std::process::Output> {
-    Command::new(command).args(args).output()
+/// Outcome of running a bounded child command. The buffers are capped so a
+/// runaway external tool cannot exhaust CLI memory before we react to it.
+#[derive(Debug)]
+struct BoundedCommandOutput {
+    status: std::process::ExitStatus,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+/// Error returned when a child process is bounded by either a wall-clock
+/// timeout or a per-stream byte cap. Both shapes give doctor diagnostics
+/// (#39) and the direct-exec fallback (#42) a clear structured failure to
+/// report instead of hanging or buffering unbounded output.
+#[derive(Debug)]
+enum BoundedCommandError {
+    Spawn(std::io::Error),
+    Io(std::io::Error),
+    TimedOut { elapsed_ms: u128 },
+    OutputTooLarge,
+}
+
+impl BoundedCommandError {
+    fn message(&self, command: &str) -> String {
+        match self {
+            Self::Spawn(error) => format!("Failed to launch {command}: {error}"),
+            Self::Io(error) => format!("Failed to read output from {command}: {error}"),
+            Self::TimedOut { elapsed_ms } => {
+                format!("{command} did not finish within {elapsed_ms}ms and was terminated.")
+            }
+            Self::OutputTooLarge => {
+                format!("{command} produced more output than the configured cap allows.")
+            }
+        }
+    }
+}
+
+/// Run `command args` and return its bounded stdout/stderr, terminating the
+/// child if it runs longer than `timeout` or emits more than `max_bytes` on
+/// either stream. Replaces a previous `Command::output()` call that allowed
+/// a hung or chatty external tool to block the caller or buffer unbounded
+/// output. See issues #39 (doctor CI diagnostics) and #42 (direct-exec
+/// fallback).
+fn run_bounded_command(
+    command: &str,
+    args: &[&str],
+    timeout: Duration,
+    max_bytes: usize,
+) -> std::result::Result<BoundedCommandOutput, BoundedCommandError> {
+    let mut command_builder = Command::new(command);
+    command_builder
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    // SAFETY: `pre_exec` runs after fork and before exec. The closure only
+    // calls `libc::setsid()`, which is async-signal-safe. Putting the child
+    // in its own process group lets us deliver SIGKILL to any orphaned
+    // grandchildren on timeout instead of leaking pipes when the immediate
+    // child is a shell that has forked a long-running tool.
+    unsafe {
+        command_builder.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let mut child = command_builder
+        .spawn()
+        .map_err(BoundedCommandError::Spawn)?;
+    let pid = child.id() as i32;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| BoundedCommandError::Io(std::io::Error::other("missing stdout pipe")))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| BoundedCommandError::Io(std::io::Error::other("missing stderr pipe")))?;
+
+    let stdout_cap = max_bytes;
+    let stderr_cap = max_bytes;
+    let stdout_reader = std::thread::spawn(move || {
+        let mut buffer = Vec::with_capacity(stdout_cap.min(8 * 1024));
+        stdout
+            .take((stdout_cap + 1) as u64)
+            .read_to_end(&mut buffer)
+            .map(|_| buffer)
+    });
+    let stderr_reader = std::thread::spawn(move || {
+        let mut buffer = Vec::with_capacity(stderr_cap.min(8 * 1024));
+        stderr
+            .take((stderr_cap + 1) as u64)
+            .read_to_end(&mut buffer)
+            .map(|_| buffer)
+    });
+
+    let started = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if started.elapsed() >= timeout {
+                    // Kill the entire process group so an orphaned tool that
+                    // inherited our stdout pipe (e.g. `sh -c 'sleep 30'`) is
+                    // also reaped and the reader threads can drain.
+                    unsafe {
+                        libc::kill(-pid, libc::SIGKILL);
+                    }
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let _ = stdout_reader.join();
+                    let _ = stderr_reader.join();
+                    return Err(BoundedCommandError::TimedOut {
+                        elapsed_ms: started.elapsed().as_millis(),
+                    });
+                }
+                std::thread::sleep(Duration::from_millis(BOUNDED_COMMAND_POLL_MS));
+            }
+            Err(error) => return Err(BoundedCommandError::Io(error)),
+        }
+    };
+
+    let stdout = stdout_reader
+        .join()
+        .map_err(|_| BoundedCommandError::Io(std::io::Error::other("stdout reader panicked")))?
+        .map_err(BoundedCommandError::Io)?;
+    let stderr = stderr_reader
+        .join()
+        .map_err(|_| BoundedCommandError::Io(std::io::Error::other("stderr reader panicked")))?
+        .map_err(BoundedCommandError::Io)?;
+
+    if stdout.len() > max_bytes || stderr.len() > max_bytes {
+        return Err(BoundedCommandError::OutputTooLarge);
+    }
+
+    Ok(BoundedCommandOutput {
+        status,
+        stdout,
+        stderr,
+    })
 }
 
 fn command_version_check(id: &str, command: &str, args: &[&str], hint: &str) -> Value {
-    match command_output(command, args) {
+    let timeout = Duration::from_millis(DOCTOR_PROBE_TIMEOUT_MS);
+    match run_bounded_command(command, args, timeout, MAX_BROKER_BYTES) {
         Ok(output) if output.status.success() => {
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -263,12 +408,21 @@ fn command_version_check(id: &str, command: &str, args: &[&str], hint: &str) -> 
             format!("{command} exited with status {}", output.status),
             hint,
         ),
-        Err(_) => diagnostic("FAIL", id, format!("{command} was not found"), hint),
+        Err(BoundedCommandError::Spawn(_)) => {
+            diagnostic("FAIL", id, format!("{command} was not found"), hint)
+        }
+        Err(error) => diagnostic("FAIL", id, error.message(command), hint),
     }
 }
 
 fn code_signing_identity_check() -> Value {
-    match command_output("security", &["find-identity", "-v", "-p", "codesigning"]) {
+    let timeout = Duration::from_millis(DOCTOR_PROBE_TIMEOUT_MS);
+    match run_bounded_command(
+        "security",
+        &["find-identity", "-v", "-p", "codesigning"],
+        timeout,
+        MAX_BROKER_BYTES,
+    ) {
         Ok(output) if output.status.success() => {
             let stdout = String::from_utf8_lossy(&output.stdout);
             if stdout.contains("Developer ID Application") {
@@ -296,11 +450,17 @@ fn code_signing_identity_check() -> Value {
             ),
             "Run `security find-identity -v -p codesigning` on the release runner.",
         ),
-        Err(_) => diagnostic(
+        Err(BoundedCommandError::Spawn(_)) => diagnostic(
             "WARN",
             "developer_id_identity",
             "security CLI was not found",
             "Run release signing diagnostics on macOS with Xcode command line tools installed.",
+        ),
+        Err(error) => diagnostic(
+            "WARN",
+            "developer_id_identity",
+            error.message("security find-identity"),
+            "Run `security find-identity -v -p codesigning` on the release runner.",
         ),
     }
 }
@@ -611,23 +771,34 @@ fn send_request_via_executable(command: &str, payload: Value) -> Result<Value> {
             format!("Failed to encode native app fallback request: {error}"),
         )
     })?;
-    let output = Command::new(&executable)
-        .arg("request")
-        .arg(command)
-        .arg(payload_arg)
-        .output()
-        .map_err(|error| {
-            APWError::new(
-                Status::ProcessNotRunning,
-                format!("Failed to execute the APW app directly: {error}"),
-            )
-        })?;
-    if output.stdout.len() > MAX_BROKER_BYTES {
-        return Err(APWError::new(
+    let executable_str = executable.to_string_lossy().into_owned();
+    let timeout = Duration::from_millis(NATIVE_APP_DIRECT_EXEC_TIMEOUT_MS);
+    let output = run_bounded_command(
+        &executable_str,
+        &["request", command, &payload_arg],
+        timeout,
+        MAX_BROKER_BYTES,
+    )
+    .map_err(|error| match error {
+        BoundedCommandError::Spawn(error) => APWError::new(
+            Status::ProcessNotRunning,
+            format!("Failed to execute the APW app directly: {error}"),
+        ),
+        BoundedCommandError::Io(error) => APWError::new(
+            Status::CommunicationTimeout,
+            format!("Failed to read direct response from the APW app: {error}"),
+        ),
+        BoundedCommandError::TimedOut { elapsed_ms } => APWError::new(
+            Status::CommunicationTimeout,
+            format!(
+                "APW app direct execution did not respond within {elapsed_ms}ms and was terminated."
+            ),
+        ),
+        BoundedCommandError::OutputTooLarge => APWError::new(
             Status::ProtoInvalidResponse,
             "Native app direct response payload too large.",
-        ));
-    }
+        ),
+    })?;
     let value: Value = serde_json::from_slice(&output.stdout).map_err(|error| {
         APWError::new(
             Status::ProtoInvalidResponse,
@@ -2147,5 +2318,68 @@ print(json.dumps({
             let payload = native_app_login("https://example.com", true).unwrap();
             assert_eq!(payload["transport"], "direct_exec");
         });
+    }
+
+    #[test]
+    fn run_bounded_command_caps_stdout_above_max() {
+        // Issue #42 (also covers #39): writing more than max_bytes on stdout
+        // must surface OutputTooLarge instead of letting the buffer grow.
+        let timeout = Duration::from_secs(5);
+        let max = 1024;
+        let result = run_bounded_command(
+            "/bin/sh",
+            &["-c", "yes A | tr -d '\\n' | head -c 8192"],
+            timeout,
+            max,
+        );
+        match result {
+            Err(BoundedCommandError::OutputTooLarge) => {}
+            other => panic!("expected OutputTooLarge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn run_bounded_command_terminates_hung_child() {
+        // Issue #39 + #42: a child that exceeds the timeout must be killed
+        // and the helper must surface TimedOut.
+        let timeout = Duration::from_millis(300);
+        let max = 4096;
+        let started = Instant::now();
+        let result = run_bounded_command("/bin/sh", &["-c", "sleep 30"], timeout, max);
+        let elapsed = started.elapsed();
+        match result {
+            Err(BoundedCommandError::TimedOut { .. }) => {}
+            other => panic!("expected TimedOut, got {other:?}"),
+        }
+        // Helper should kill the child shortly after the configured budget;
+        // give some slack for thread scheduling but never approach 30s.
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "expected fast termination, took {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn run_bounded_command_returns_status_and_output_for_quick_child() {
+        let timeout = Duration::from_secs(5);
+        let result = run_bounded_command("/bin/sh", &["-c", "printf hello"], timeout, 4096)
+            .expect("expected success");
+        assert!(result.status.success());
+        assert_eq!(result.stdout, b"hello");
+    }
+
+    #[test]
+    fn run_bounded_command_reports_spawn_error_for_missing_binary() {
+        let timeout = Duration::from_secs(5);
+        let result = run_bounded_command(
+            "/this/definitely/does/not/exist/apw-test",
+            &[],
+            timeout,
+            4096,
+        );
+        match result {
+            Err(BoundedCommandError::Spawn(_)) => {}
+            other => panic!("expected Spawn error, got {other:?}"),
+        }
     }
 }

--- a/rust/tests/native_app_e2e.rs
+++ b/rust/tests/native_app_e2e.rs
@@ -183,6 +183,21 @@ def maybe_emit_direct_override():
         sys.stdout.write(json.dumps({"ok": True, "code": 0}))
         sys.stdout.flush()
         return True
+    if mode == "flood":
+        # Emit far more than MAX_MESSAGE_BYTES (32 KiB) without ever closing
+        # stdout to a sentinel. The bounded read in the Rust CLI must cap
+        # this without growing past the configured limit. See issue #42.
+        chunk = b"A" * 4096
+        for _ in range(64):
+            sys.stdout.buffer.write(chunk)
+            sys.stdout.buffer.flush()
+        return True
+    if mode == "hang":
+        # Sleep past the direct-exec timeout to force the bounded helper to
+        # terminate the child. The CLI must surface a CommunicationTimeout
+        # rather than block. See issue #42.
+        time.sleep(30)
+        return True
     return False
 
 
@@ -709,4 +724,63 @@ fn direct_fallback_maps_malformed_response_to_proto_invalid_response() {
         .as_str()
         .unwrap_or_default()
         .contains("missing its payload"));
+}
+
+#[test]
+#[serial]
+fn direct_fallback_bounds_oversized_stdout() {
+    // Issue #42: a fallback executable that streams unbounded output must
+    // be capped before the CLI buffers the full payload. Previously the
+    // CLI used Command::output() and only checked the length after the
+    // child exited.
+    let fixture = NativeAppFixture::new();
+
+    let install = run_apw(&fixture, &["--json", "app", "install"], &[]);
+    assert_eq!(install.status, 0, "{install:#?}");
+
+    let flood = run_apw(
+        &fixture,
+        &["--json", "login", "https://example.com"],
+        &[("APW_FAKE_DIRECT_RESPONSE", "flood")],
+    );
+    assert_eq!(flood.status, 104, "{flood:#?}");
+    let payload = parse_error(&flood);
+    let error = payload["error"].as_str().unwrap_or_default();
+    assert!(
+        error.contains("too large"),
+        "expected oversize error, got {error}"
+    );
+}
+
+#[test]
+#[serial]
+fn direct_fallback_terminates_hung_child() {
+    // Issue #42: a fallback executable that never exits must be terminated
+    // by the CLI rather than blocking it forever. The bounded helper
+    // surfaces a CommunicationTimeout (code 101).
+    let fixture = NativeAppFixture::new();
+
+    let install = run_apw(&fixture, &["--json", "app", "install"], &[]);
+    assert_eq!(install.status, 0, "{install:#?}");
+
+    let started = std::time::Instant::now();
+    let hung = run_apw(
+        &fixture,
+        &["--json", "login", "https://example.com"],
+        &[("APW_FAKE_DIRECT_RESPONSE", "hang")],
+    );
+    let elapsed = started.elapsed();
+
+    assert_eq!(hung.status, 101, "{hung:#?}");
+    let payload = parse_error(&hung);
+    let error = payload["error"].as_str().unwrap_or_default();
+    assert!(
+        error.contains("did not respond"),
+        "expected timeout error, got {error}"
+    );
+    // The fake app sleeps 30s; the CLI must terminate it well before that.
+    assert!(
+        elapsed < Duration::from_secs(15),
+        "expected timeout within 15s, took {elapsed:?}"
+    );
 }

--- a/scripts/ci/run-extended-validation.sh
+++ b/scripts/ci/run-extended-validation.sh
@@ -20,6 +20,38 @@ run_step() {
   "$@"
 }
 
+# Issue #40: openssl-sys discovery on macOS requires pkg-config and a
+# locatable OpenSSL prefix. The workflow caller exports these via
+# $GITHUB_ENV; we mirror the discovery here so direct shell invocations on a
+# clean macOS host (or runner steps that bypass the workflow) still succeed
+# with a clear error if the toolchain is unavailable.
+ensure_openssl_on_macos() {
+  [[ "${OSTYPE:-}" == darwin* ]] || return 0
+  if [[ -n "${OPENSSL_DIR:-}" ]] && command -v pkg-config >/dev/null 2>&1; then
+    return 0
+  fi
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "Homebrew is required on macOS to locate OpenSSL for openssl-sys." >&2
+    echo "Install Homebrew or export OPENSSL_DIR/PKG_CONFIG_PATH manually." >&2
+    exit 1
+  fi
+  if ! command -v pkg-config >/dev/null 2>&1; then
+    brew list pkg-config >/dev/null 2>&1 || brew install pkg-config
+  fi
+  local prefix
+  prefix="$(brew --prefix openssl@3 2>/dev/null || true)"
+  if [[ -z "$prefix" || ! -d "$prefix" ]]; then
+    brew install openssl@3
+    prefix="$(brew --prefix openssl@3)"
+  fi
+  export OPENSSL_DIR="$prefix"
+  export OPENSSL_INCLUDE_DIR="$prefix/include"
+  export OPENSSL_LIB_DIR="$prefix/lib"
+  export PKG_CONFIG_PATH="$prefix/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+}
+
+ensure_openssl_on_macos
+
 require_tool cargo
 require_tool swift
 


### PR DESCRIPTION
## Summary

Groups three related open issues — all about bounding subprocess execution and
provisioning the macOS extended-validation runner — into a single focused PR.

Closes #39, #42, #40.

### #39 — `apw doctor` CI diagnostics had no timeout

`command_output()` (used by the `xcodebuild` / `cargo` / `detect-secrets` /
`security find-identity` probes in `ci_diagnostic_checks`) called
`Command::output()` directly. A misconfigured shim that hung would hang
`apw doctor` itself, defeating its purpose as the first readiness check.

### #42 — direct-exec fallback buffered unbounded stdout

`send_request_via_executable()` also called `Command::output()`, which buffers
the *full* child stdout before the `MAX_BROKER_BYTES` length check ran. A
fallback provider streaming unbounded output could grow CLI memory until the
child exited. The docs claimed responses were "bounded… before JSON decoding,"
which did not match the implementation.

### #40 — Extended Validation OpenSSL/pkg-config missing on macOS runner

`openssl-sys` build script failed on the `[self-hosted, private, macOS, ARM64,
xcode]` runner because `pkg-config` and a discoverable OpenSSL were not
provisioned.

## Implementation

- **New helper `run_bounded_command`** in `rust/src/native_app.rs`. Spawns the
  child with `setsid()`, piped stdout/stderr capped at `MAX_BROKER_BYTES` via
  `.take()`, a wall-clock timeout, and a process-group SIGKILL on timeout so an
  orphaned grandchild (e.g. `sh -c 'sleep 30'`) can't keep our read pipes open.
- `command_version_check`, `code_signing_identity_check`,
  `send_request_via_executable` all route through the new helper.
  - Doctor probes: 3s timeout per probe.
  - Direct-exec fallback: 5s timeout, surfaces `CommunicationTimeout` (101) on
    hang and `ProtoInvalidResponse` (104) on oversized stdout.
- `docs/SECURITY_POSTURE_AND_TESTING.md` updated to accurately describe the
  bounded reads and per-probe timeouts.
- `.github/workflows/extended-validation.yml` installs `pkg-config` and
  `openssl@3` via `brew` and exports `OPENSSL_DIR` / `PKG_CONFIG_PATH` via
  `$GITHUB_ENV` so the existing `dtolnay/rust-toolchain` step finds them.
- `scripts/ci/run-extended-validation.sh` mirrors the provisioning for direct
  shell invocations on a clean macOS host.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 189 tests pass (160 unit + 7 legacy_parity + 12 e2e + 10 security_regressions); +4 new unit tests + 2 new e2e tests
- [x] `bash -n scripts/ci/run-extended-validation.sh`
- [x] Manual: doctor with a fake hung `xcodebuild` now reports `FAIL: did not finish within 3017ms and was terminated.` after 3s instead of hanging
- [ ] Extended Validation lane (#40 portion) needs to actually run on the macOS runner to confirm the OpenSSL provisioning works — can't verify from this Linux container

### Roadmap items NOT addressed

Issues #43–#58 are explicitly labeled `roadmap` and call for decisions, spike
work, or sustained engineering effort (notarization automation, Sparkle
updater, MDM config, etc.). They're out of scope for a single grouped bug-fix
PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_016wf7U6ZzPCENfLrYYN5Xqn)_