### PR TITLE
Record docs-site publishing decision

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,3 +13,16 @@ Start here for the maintained APW v2 documentation set.
 
 Bootstrap and contributor environment notes live under
 [`bootstrap/`](bootstrap/).
+
+## Publication decision
+
+APW keeps the maintained documentation as repository Markdown under `docs/`.
+There is no GitHub Pages or external rendered docs site for the current
+`v2.0.0` line. `project.bootstrap.yaml` intentionally keeps
+`ci.workflows.pagesDeploy`, `capabilities.pages.enabled`, and
+`capabilities.docsPublish.enabled` set to `false`.
+
+This avoids duplicating normative content while the native-app broker,
+notarization, distribution, and enterprise rollout docs are still changing.
+When those surfaces stabilize, a future release-docs issue can revisit a
+rendered site that builds from the same Markdown source.

--- a/project.bootstrap.yaml
+++ b/project.bootstrap.yaml
@@ -84,6 +84,8 @@ ci:
     prFastCi: true
     extendedValidation: true
     claude: true
+    # Issue #58 decision: keep APW docs markdown-only for now. Do not add a
+    # Pages workflow until release-published operator docs need stable URLs.
     pagesDeploy: false
     ci: false
     extras: []
@@ -99,6 +101,8 @@ agents:
   sharedSkills: []
 capabilities:
   pages:
+    # Issue #58 decision: docs are served from the repository README/docs tree,
+    # not a rendered Pages site, until the release docs surface stabilizes.
     enabled: false
     provider: cloudflare-pages
     outputDir: dist
@@ -106,6 +110,7 @@ capabilities:
     enabled: false
     kind: none
   docsPublish:
+    # Issue #58 decision: no separate docs publishing pipeline.
     enabled: false
   containers:
     enabled: false


### PR DESCRIPTION
## Summary

Records the issue #58 docs-site decision: keep APW documentation markdown-only in the repository for the current v2 line rather than adding a GitHub Pages or external rendered-docs pipeline now.

Closes #58.

## Why

The current bootstrap manifest already has `ci.workflows.pagesDeploy`, `capabilities.pages.enabled`, and `capabilities.docsPublish.enabled` disabled. Keeping that as the explicit decision avoids duplicating normative docs while native-app broker, notarization, distribution, and enterprise rollout documentation are still changing.

## Changes

- Adds the publication decision to `docs/README.md`.
- Records the same decision next to the relevant `project.bootstrap.yaml` docs publishing controls.

## Verification

- `bash scripts/ci/run-fast-checks.sh` passed.
- `ruby -e 'require "yaml"; YAML.load_file("project.bootstrap.yaml"); puts "project.bootstrap.yaml parses"'` passed.
- `git diff --check` passed.
