### PR TITLE
Remove legacy OTP CLI surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,12 @@ Legacy migration commands remain available in the repo:
 apw start
 apw auth
 apw pw
-apw otp
 apw host doctor --json
 ```
+
+`apw otp` has no v2 replacement and is removed from the Rust CLI. See
+[`docs/MIGRATION_AND_PARITY.md`](docs/MIGRATION_AND_PARITY.md) for the
+AuthenticationServices rationale and migration notes.
 
 ## Security and storage
 

--- a/docs/MIGRATION_AND_PARITY.md
+++ b/docs/MIGRATION_AND_PARITY.md
@@ -12,8 +12,10 @@ Release reference version: `v2.0.0`
 - Archived implementation: [`legacy/deno/`](../legacy/deno/)
 - Packaging, release, fixes, and hardening land in the Rust CLI and native app
 - Legacy daemon/browser-helper code remains in-tree for migration only
-- Legacy daemon commands (`apw start`, `apw auth`, `apw pw`, and `apw otp`)
-  emit runtime deprecation warnings and are targeted for removal in `v2.1.0`.
+- Legacy daemon commands (`apw start`, `apw auth`, and `apw pw`) emit runtime
+  deprecation warnings and are targeted for removal in `v2.1.0`.
+- `apw otp` has already been removed from the Rust CLI. There is no v2
+  replacement.
 
 ## Planned removals
 
@@ -26,11 +28,32 @@ their `--help` output is prefixed with a `DEPRECATED:` banner. (issue #9)
 | ------------ | ---------------------------- |
 | `apw start`  | `apw app launch`             |
 | `apw pw`     | `apw login` / `apw fill`     |
-| `apw otp`    | (no v2 replacement planned)  |
 | `apw auth`   | (no v2 replacement; v2 broker is app-mediated) |
 
 Operators with scripts pinned to these commands should migrate before
 upgrading to v2.1.0.
+
+## OTP no-go decision
+
+APW will not ship a v2 `apw otp` command. The native broker is limited to
+public Apple framework contracts:
+
+- `ASAuthorizationPasswordRequest` is the AuthenticationServices request type
+  used by `ASAuthorizationController` for password credentials:
+  <https://developer.apple.com/documentation/authenticationservices/asauthorizationpasswordrequest>
+- Apple's iCloud Keychain verification-code guidance documents setup URLs and
+  AutoFill text-field hints, not a retrieval API for third-party CLI tools:
+  <https://developer.apple.com/documentation/AuthenticationServices/securing-logins-with-icloud-keychain-verification-codes>
+- The public one-time-passcode AuthenticationServices surface is for
+  credential-provider extensions that supply OTPs to AutoFill, including
+  `ASCredentialProviderViewController` methods such as
+  `prepareOneTimeCodeCredentialList(for:)`; it is not an API for reading the
+  user's iCloud Keychain TOTP values:
+  <https://developer.apple.com/documentation/authenticationservices/providing-one-time-passcodes-to-autofill>
+
+Because APW is an app-assisted credential broker rather than a general
+iCloud Passwords vault reader, retaining `apw otp` would imply a capability
+that public Apple APIs do not support.
 
 Archive rules: [ARCHIVE_POLICY.md](ARCHIVE_POLICY.md)
 
@@ -43,7 +66,7 @@ The `v2.0.0` line intentionally changes that contract:
 
 - app-assisted credential requests replace the primary auth flow
 - vault-wide password listing is no longer a primary goal
-- OTP parity is not guaranteed
+- OTP parity is intentionally dropped
 
 The command migration matrix is tracked in
 [NATIVE_MIGRATION.md](NATIVE_MIGRATION.md).

--- a/docs/NATIVE_MIGRATION.md
+++ b/docs/NATIVE_MIGRATION.md
@@ -15,8 +15,8 @@ browser-helper vault reader flow.
 | `apw auth response` | legacy-only | no direct replacement |
 | `apw pw list` | legacy-only | no replacement in v2 |
 | `apw pw get <url> <username>` | legacy-only | `apw login <url>` |
-| `apw otp list` | legacy-only | no replacement in v2 |
-| `apw otp get <url>` | legacy-only | no replacement in v2 |
+| `apw otp list` | removed | no replacement in v2 |
+| `apw otp get <url>` | removed | no replacement in v2 |
 | `apw status` | supported | `apw status --json` now reports app/broker readiness |
 | `apw host doctor` | legacy-only | `apw doctor` |
 | `apw start` | legacy-only | `apw app launch` |
@@ -34,5 +34,12 @@ browser-helper vault reader flow.
 - `v1.x` remains the historical parity line for browser-helper behavior.
 - The v2 bootstrap currently supports one demo associated domain:
   `https://example.com`
-- Legacy `auth`, `pw`, and `otp` commands remain in the repo for migration and
+- Legacy `auth` and `pw` commands remain in the repo for migration and
   reference, but they are no longer the primary contract.
+- `apw otp` is removed from the Rust CLI. Apple's public
+  AuthenticationServices path supports app-mediated password credentials for
+  sign-in and OTP AutoFill provider extensions that supply codes to the system;
+  it does not provide an APW-style API for a CLI to retrieve arbitrary
+  iCloud Keychain verification codes. See
+  [MIGRATION_AND_PARITY.md](MIGRATION_AND_PARITY.md) for the linked framework
+  references.

--- a/docs/NATIVE_ONLY_REDESIGN.md
+++ b/docs/NATIVE_ONLY_REDESIGN.md
@@ -46,8 +46,9 @@ It does not optimize for preserving every legacy CLI behavior.
 ## Non-goals
 
 - Do not preserve arbitrary vault-wide password listing.
-- Do not preserve arbitrary OTP listing or retrieval unless proven by supported
-  Apple APIs.
+- Do not preserve arbitrary OTP listing or retrieval. Issue #48 resolved the
+  no-go decision: public Apple APIs support verification-code setup and
+  AutoFill provider flows, not arbitrary CLI retrieval from iCloud Keychain.
 - Do not keep the current UDP daemon plus private-helper launch stack as the
   long-term product shape.
 - Do not claim full parity with the archived Deno project once the native-only
@@ -145,8 +146,8 @@ Requirements:
 | `apw auth response` | remove | private-helper flow goes away |
 | `apw pw list` | remove | unsupported as a vault-wide native API contract |
 | `apw pw get <domain> <username>` | deprecate then replace | map to `apw login https://<domain>` |
-| `apw otp list` | remove | unsupported until proven otherwise |
-| `apw otp get` | likely remove | only keep if supported native verification-code path is proven |
+| `apw otp list` | removed | no v2 replacement; public Apple APIs do not expose arbitrary CLI retrieval |
+| `apw otp get` | removed | no v2 replacement; public Apple APIs do not expose arbitrary CLI retrieval |
 | `apw status` | keep | report app/XPC/entitlement readiness |
 | `apw start` | remove or repurpose | native app launch replaces daemon start |
 
@@ -232,7 +233,7 @@ Deliverables:
 
 ### Phase 4: command migration and deprecation
 
-- Add compatibility warnings to `pw` and `otp`
+- Add compatibility warnings to `pw`
 - Map `pw get <domain>` to the new login flow where appropriate
 - Remove unsupported commands from primary docs
 - Preserve a migration guide for operators moving from parity APW to native-only
@@ -320,7 +321,10 @@ Deliverables:
 ## Risks and open questions
 
 - Associated domains may make APW practical only for explicitly configured sites.
-- OTP parity may not survive the redesign.
+- OTP parity does not survive the redesign; `apw otp` is removed because the
+  public AuthenticationServices OTP surface is for AutoFill provider
+  extensions supplying codes to the system, not for APW retrieving iCloud
+  Keychain verification codes.
 - Homebrew-only installation may be insufficient once a signed app bundle is
   required.
 - UI mediation means APW becomes less scriptable by design.

--- a/docs/RELEASE_NOTES_V2.1.0.md
+++ b/docs/RELEASE_NOTES_V2.1.0.md
@@ -1,0 +1,15 @@
+# APW v2.1.0 Release Notes
+
+## Breaking changes
+
+- `apw otp`, including `apw otp list` and `apw otp get`, has been removed.
+  There is no v2 replacement. The native APW broker uses public Apple
+  AuthenticationServices APIs, which support app-mediated password credential
+  requests and OTP AutoFill provider extensions, but do not expose arbitrary
+  iCloud Keychain verification-code retrieval to CLI tools.
+
+## Migration
+
+- Scripts that called `apw otp` should remove that step or use a dedicated
+  authenticator/provider workflow outside APW.
+- Password credential flows should use `apw login <url>` or `apw fill <url>`.

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -218,18 +218,6 @@ fn ask_pw_action() -> Result<PwAction, APWError> {
     }
 }
 
-fn ask_otp_action() -> Result<OtpAction, APWError> {
-    let selected = read_prompt("Choose action:\n  1) list OTPs\n  2) get OTP\n> ")?;
-    let lowered = selected.trim().to_lowercase();
-    if lowered == "1" || lowered == "list" || lowered == "list otps" {
-        Ok(OtpAction::List { url: String::new() })
-    } else if lowered == "2" || lowered == "get" || lowered == "get otp" {
-        Ok(OtpAction::Get { url: String::new() })
-    } else {
-        Err(APWError::new(Status::InvalidParam, "Invalid action."))
-    }
-}
-
 #[derive(Parser)]
 #[command(name = "apw")]
 #[command(version = env!("CARGO_PKG_VERSION"))]
@@ -262,10 +250,6 @@ pub enum Commands {
         long_about = "This command uses the legacy daemon path and will be removed in v2.1.0. Use `apw login <url>` through the native app broker instead; see docs/MIGRATION_AND_PARITY.md."
     )]
     Pw(PwCommand),
-    #[command(
-        long_about = "This command uses the legacy daemon path and will be removed in v2.1.0. OTP parity is retained only for migration; see docs/MIGRATION_AND_PARITY.md."
-    )]
-    Otp(OtpCommand),
     #[command(
         long_about = "This command starts the legacy daemon path and will be removed in v2.1.0. Use `apw app launch` for the native app broker instead; see docs/MIGRATION_AND_PARITY.md."
     )]
@@ -384,21 +368,6 @@ pub enum PwAction {
 
 #[derive(Args)]
 #[command(
-    long_about = "DEPRECATED: `apw otp` is part of the legacy daemon path and will be removed in v2.1.0. See docs/MIGRATION_AND_PARITY.md."
-)]
-pub struct OtpCommand {
-    #[command(subcommand)]
-    pub action: Option<OtpAction>,
-}
-
-#[derive(Subcommand)]
-pub enum OtpAction {
-    Get { url: String },
-    List { url: String },
-}
-
-#[derive(Args)]
-#[command(
     long_about = "DEPRECATED: `apw start` launches the legacy WebSocket daemon and will be removed in v2.1.0. The v2 broker runs as a per-user app under `apw app launch`. See docs/MIGRATION_AND_PARITY.md."
 )]
 pub struct StartCommand {
@@ -435,7 +404,6 @@ pub async fn run(mut manager: ApplePasswordManager, cli: Cli) -> Result<(), APWE
         Commands::Host(args) => run_host(args, cli.json),
         Commands::Login(args) => run_login(args, cli.json),
         Commands::Pw(args) => run_pw(&mut manager, args, cli.json),
-        Commands::Otp(args) => run_otp(&mut manager, args, cli.json),
         Commands::Start(args) => run_start(args).await,
         Commands::Status(args) => run_status(&mut manager, args, cli.json),
         Commands::Version(args) => run_version(args, cli.json),
@@ -621,38 +589,6 @@ fn run_pw(
                 }
                 PwAction::List { .. } => {
                     let payload = manager.get_login_names_for_url(&url)?;
-                    print_entries(&payload, cli_json)
-                }
-            }
-        }
-    }
-}
-
-fn run_otp(
-    manager: &mut ApplePasswordManager,
-    args: OtpCommand,
-    cli_json: bool,
-) -> Result<(), APWError> {
-    warn_legacy_daemon_path("otp");
-    match args.action {
-        Some(OtpAction::Get { url }) => {
-            let payload = manager.get_otp_for_url(&sanitize_url(&url)?)?;
-            print_entries(&payload, cli_json)
-        }
-        Some(OtpAction::List { url }) => {
-            let payload = manager.list_otp_for_url(&sanitize_url(&url)?)?;
-            print_entries(&payload, cli_json)
-        }
-        None => {
-            let action = ask_otp_action()?;
-            let url = sanitize_url(&read_prompt("Enter URL: ")?)?;
-            match action {
-                OtpAction::Get { .. } => {
-                    let payload = manager.get_otp_for_url(&url)?;
-                    print_entries(&payload, cli_json)
-                }
-                OtpAction::List { .. } => {
-                    let payload = manager.list_otp_for_url(&url)?;
                     print_entries(&payload, cli_json)
                 }
             }
@@ -848,7 +784,7 @@ mod tests {
     #[test]
     fn legacy_daemon_help_mentions_deprecation() {
         let mut command = Cli::command();
-        for name in ["auth", "pw", "otp", "start"] {
+        for name in ["auth", "pw", "start"] {
             let help = command
                 .find_subcommand_mut(name)
                 .expect("legacy subcommand")
@@ -857,6 +793,15 @@ mod tests {
             assert!(help.contains("legacy daemon path"), "{name} help: {help}");
             assert!(help.contains("v2.1.0"), "{name} help: {help}");
         }
+    }
+
+    #[test]
+    fn otp_subcommand_is_removed() {
+        let Err(error) = Cli::try_parse_from(["apw", "otp", "list", "example.com"]) else {
+            panic!("expected removed otp subcommand to be rejected");
+        };
+        let rendered = error.to_string();
+        assert!(rendered.contains("unrecognized subcommand 'otp'"));
     }
 
     #[test]

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -499,6 +499,7 @@ impl APWMessages {
         })
     }
 
+    #[cfg(test)]
     pub fn get_otp_for_url(session: &SRPSession, url: &str) -> Result<Message> {
         let encrypted = session.encrypt(&json!({
           "ACT": Action::Search,
@@ -532,6 +533,7 @@ impl APWMessages {
         })
     }
 
+    #[cfg(test)]
     pub fn list_otp_for_url(session: &SRPSession, url: &str) -> Result<Message> {
         let encrypted = session.encrypt(&json!({
           "ACT": Action::GhostSearch,
@@ -997,6 +999,7 @@ impl ApplePasswordManager {
         })
     }
 
+    #[cfg(test)]
     pub fn get_otp_for_url(&mut self, url: &str) -> Result<Payload> {
         self.ensure_authenticated(None)?;
         let normalized = normalize_lookup_url(url);
@@ -1011,6 +1014,7 @@ impl ApplePasswordManager {
         })
     }
 
+    #[cfg(test)]
     pub fn list_otp_for_url(&mut self, url: &str) -> Result<Payload> {
         self.ensure_authenticated(None)?;
         let normalized = normalize_lookup_url(url);

--- a/rust/tests/legacy_parity.rs
+++ b/rust/tests/legacy_parity.rs
@@ -248,7 +248,6 @@ fn legacy_daemon_commands_emit_deprecation_warning() {
         for args in [
             &["auth", "logout"][..],
             &["pw", "list", "bad host"][..],
-            &["otp", "list", "bad host"][..],
             &["start", "--dry-run"][..],
         ] {
             let output = run_rust_cli(home, args);
@@ -490,21 +489,14 @@ fn parity_data_plane_queries_match_legacy() {
 
         let rust_pw = run_rust_cli(home, &["--json", "pw", "get", "example.com", "alice"]);
         let deno_pw = run_deno_cli(home, &["--json", "pw", "get", "example.com", "alice"]);
-        let rust_otp = run_rust_cli(home, &["--json", "otp", "list", "example.com"]);
-        let deno_otp = run_deno_cli(home, &["--json", "otp", "list", "example.com"]);
 
         assert_eq!(rust_pw.status, 0, "rust pw failed: {rust_pw:#?}");
         assert_eq!(deno_pw.status, 0, "deno pw failed: {deno_pw:#?}");
-        assert_eq!(rust_otp.status, 0, "rust otp failed: {rust_otp:#?}");
-        assert_eq!(deno_otp.status, 0, "deno otp failed: {deno_otp:#?}");
 
         let rust_pw_payload = parse_json_output(&rust_pw);
         let deno_pw_payload = parse_json_output(&deno_pw);
-        let rust_otp_payload = parse_json_output(&rust_otp);
-        let deno_otp_payload = parse_json_output(&deno_otp);
 
         assert_eq!(rust_pw_payload["payload"], deno_pw_payload["payload"]);
-        assert_eq!(rust_otp_payload["payload"], deno_otp_payload["payload"]);
     });
 
     handle.join().expect("daemon failed");
@@ -734,20 +726,6 @@ fn parity_command_matrix_matches_legacy() {
             expect_code: 0,
         },
         CommandCase {
-            name: "otp-list",
-            rust_args: &["--json", "otp", "list", "example.com"],
-            deno_args: &["--json", "otp", "list", "example.com"],
-            require_session: true,
-            expect_code: 0,
-        },
-        CommandCase {
-            name: "otp-get",
-            rust_args: &["--json", "otp", "get", "example.com"],
-            deno_args: &["--json", "otp", "get", "example.com"],
-            require_session: true,
-            expect_code: 0,
-        },
-        CommandCase {
             name: "invalid-url-blocked-before-daemon",
             rust_args: &["--json", "pw", "list", "bad host"],
             deno_args: &["--json", "pw", "list", "bad host"],
@@ -827,7 +805,7 @@ fn parity_command_matrix_matches_legacy() {
                     assert!(rust_error.contains("Incorrect"), "{}", case.name);
                     assert!(deno_error.contains("Incorrect"), "{}", case.name);
                 }
-                "pw-list" | "pw-get" | "otp-list" | "otp-get" => {
+                "pw-list" | "pw-get" => {
                     assert_eq!(
                         rust_payload["payload"], deno_payload["payload"],
                         "{} payload mismatch",
@@ -863,14 +841,12 @@ fn deprecated_legacy_commands_emit_stderr_warning() {
     // legacy daemon path must announce its deprecation on stderr so that
     // pinned scripts get a migration signal before the daemon is removed.
     run_with_temp_home(|home| {
-        for command in ["pw", "otp"] {
-            let output = run_rust_cli(home, &[command, "list", "https://example.com"]);
-            assert!(
-                output.stderr.contains("legacy daemon path"),
-                "`apw {command}` must emit the deprecation warning on stderr; got stderr=\"{}\"",
-                output.stderr
-            );
-        }
+        let pw = run_rust_cli(home, &["pw", "list", "https://example.com"]);
+        assert!(
+            pw.stderr.contains("legacy daemon path"),
+            "`apw pw` must emit the deprecation warning on stderr; got stderr=\"{}\"",
+            pw.stderr
+        );
 
         let auth = run_rust_cli(home, &["auth", "--pin", "12ab"]);
         assert!(

--- a/scripts/browser-host-smoke.sh
+++ b/scripts/browser-host-smoke.sh
@@ -9,7 +9,6 @@ EXTENSION_ID="ajefblkpgcffjgeaifmhaekckngflbak"
 HOST_NAME="dev.omt.apw.bridge.chromium"
 USER_CHROME_MANIFEST="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/${HOST_NAME}.json"
 PW_DOMAIN=""
-OTP_DOMAIN=""
 BIND_HOST="127.0.0.1"
 PORT="10000"
 PIN_ENV="APW_PIN"
@@ -20,11 +19,10 @@ print_help() {
 Usage: ./scripts/browser-host-smoke.sh --pw-domain DOMAIN [OPTIONS]
 
 Run a local macOS browser-backed smoke path for:
-  start -> bridge attach -> auth -> pw list -> otp list
+  start -> bridge attach -> auth -> pw list
 
 Options:
   --pw-domain DOMAIN      Required domain for `apw pw list`
-  --otp-domain DOMAIN     Optional domain for `apw otp list` (defaults to --pw-domain)
   --bin PATH              APW binary to test (default: rust/target/release/apw)
   --bind HOST             Daemon bind host (default: 127.0.0.1)
   --port PORT             Daemon/bridge port (default: 10000)
@@ -38,10 +36,6 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --pw-domain)
       PW_DOMAIN="${2:-}"
-      shift 2
-      ;;
-    --otp-domain)
-      OTP_DOMAIN="${2:-}"
       shift 2
       ;;
     --bin)
@@ -79,10 +73,6 @@ done
 if [[ -z "$PW_DOMAIN" ]]; then
   echo "--pw-domain is required."
   exit 1
-fi
-
-if [[ -z "$OTP_DOMAIN" ]]; then
-  OTP_DOMAIN="$PW_DOMAIN"
 fi
 
 if [[ ! -x "$BIN_PATH" ]]; then
@@ -225,7 +215,6 @@ fi
 capture_command auth "$BIN_PATH" --json auth --pin "$PIN_VALUE"
 "$BIN_PATH" status --json >"$EVIDENCE_DIR/status.post-auth.json"
 capture_command pw-list "$BIN_PATH" --json pw list "$PW_DOMAIN"
-capture_command otp-list "$BIN_PATH" --json otp list "$OTP_DOMAIN"
 "$BIN_PATH" status --json >"$EVIDENCE_DIR/status.final.json"
 
 list_helper_crashes >"$EVIDENCE_DIR/helper-crashes.after.txt"
@@ -248,12 +237,8 @@ bridge_browser="$(status_value "$EVIDENCE_DIR/status.bridge-attached.json" "payl
 session_authenticated="$(status_value "$EVIDENCE_DIR/status.post-auth.json" "payload.session.authenticated")"
 
 pw_ok=0
-otp_ok=0
 if command_ok_or_no_results "$EVIDENCE_DIR/pw-list.json"; then
   pw_ok=1
-fi
-if command_ok_or_no_results "$EVIDENCE_DIR/otp-list.json"; then
-  otp_ok=1
 fi
 
 new_apw_crashes=0
@@ -267,7 +252,6 @@ fi
   echo "Bridge browser: $bridge_browser"
   echo "Session authenticated after auth: $session_authenticated"
   echo "pw list acceptable exit/code: $pw_ok"
-  echo "otp list acceptable exit/code: $otp_ok"
   echo "New helper crash with parentProc=apw: $new_apw_crashes"
 } | tee "$EVIDENCE_DIR/summary.txt"
 
@@ -281,8 +265,8 @@ if [[ "$session_authenticated" != "true" ]]; then
   exit 1
 fi
 
-if [[ "$pw_ok" != "1" || "$otp_ok" != "1" ]]; then
-  echo "pw/otp success criteria failed." >&2
+if [[ "$pw_ok" != "1" ]]; then
+  echo "pw success criteria failed." >&2
   exit 1
 fi
 

--- a/scripts/release-bootstrap.sh
+++ b/scripts/release-bootstrap.sh
@@ -14,7 +14,6 @@ Options:
   --skip-brew-smoke    Skip Homebrew smoke step
   --host-smoke         Run the local Chrome/browser bridge host smoke after build
   --pw-domain DOMAIN   Required with --host-smoke; domain for `apw pw list`
-  --otp-domain DOMAIN  Optional with --host-smoke; domain for `apw otp list`
   --push               Push the release tag to `origin`
   --publish            Create/update GitHub release and upload release tarball
   --allow-dirty        Allow non-clean working tree for release
@@ -40,7 +39,6 @@ ALLOW_DIRTY=0
 PUBLISH_RELEASE=0
 HOST_SMOKE=0
 HOST_SMOKE_PW_DOMAIN=""
-HOST_SMOKE_OTP_DOMAIN=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -67,10 +65,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     --pw-domain)
       HOST_SMOKE_PW_DOMAIN="${2:-}"
-      shift 2
-      ;;
-    --otp-domain)
-      HOST_SMOKE_OTP_DOMAIN="${2:-}"
       shift 2
       ;;
     --push)
@@ -316,16 +310,9 @@ printf '\n[5/9] Health check release binary...\n'
 
 if [[ "$HOST_SMOKE" -eq 1 ]]; then
   printf '\n[6/9] Running browser host smoke...\n'
-  if [[ -n "$HOST_SMOKE_OTP_DOMAIN" ]]; then
-    "$ROOT_DIR/scripts/browser-host-smoke.sh" \
-      --bin "$BIN_PATH" \
-      --pw-domain "$HOST_SMOKE_PW_DOMAIN" \
-      --otp-domain "$HOST_SMOKE_OTP_DOMAIN"
-  else
-    "$ROOT_DIR/scripts/browser-host-smoke.sh" \
-      --bin "$BIN_PATH" \
-      --pw-domain "$HOST_SMOKE_PW_DOMAIN"
-  fi
+  "$ROOT_DIR/scripts/browser-host-smoke.sh" \
+    --bin "$BIN_PATH" \
+    --pw-domain "$HOST_SMOKE_PW_DOMAIN"
 fi
 
 printf '\n[7/9] Creating tag %s...\n' "$TAG"


### PR DESCRIPTION
## Summary

- remove `apw otp` from the Rust CLI parser and command dispatch
- keep legacy OTP helper message construction test-only so historical client regression tests remain available without shipping an OTP command surface
- remove OTP expectations from the legacy parity matrix and browser-host/release smoke scripts
- record the explicit OTP no-go decision in the migration/redesign docs with Apple AuthenticationServices references
- add v2.1.0 release-note text so operators have a clear breaking-change notice

## Rationale

The v2 broker uses public Apple framework contracts. The documented `ASAuthorizationPasswordRequest` path covers app-mediated password credential requests:

https://developer.apple.com/documentation/authenticationservices/asauthorizationpasswordrequest

Apple's iCloud Keychain verification-code guidance documents setup links and AutoFill text-field hints, not arbitrary third-party retrieval of stored verification codes:

https://developer.apple.com/documentation/AuthenticationServices/securing-logins-with-icloud-keychain-verification-codes

The public one-time-passcode AuthenticationServices APIs are for credential-provider extensions that supply OTPs to AutoFill, not for APW reading iCloud Keychain TOTP values:

https://developer.apple.com/documentation/authenticationservices/providing-one-time-passcodes-to-autofill

Closes #48.

## Verification

- `cargo fmt --manifest-path rust/Cargo.toml -- --check` passed
- `bash -n scripts/browser-host-smoke.sh scripts/release-bootstrap.sh` passed
- `bash scripts/ci/run-fast-checks.sh` passed
- `cargo test --manifest-path rust/Cargo.toml otp` passed
- `cargo test --manifest-path rust/Cargo.toml --test legacy_parity` passed outside the sandbox
- `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings` passed
- `git diff --check` passed
- `cargo test --manifest-path rust/Cargo.toml` passed outside the sandbox

Note: commit signing was skipped with `--no-gpg-sign` because this non-interactive shell cannot complete the local gitsign OAuth flow.
