### PR TITLE
Localize APW approval prompt

### DIFF
--- a/docs/SECURITY_POSTURE_AND_TESTING.md
+++ b/docs/SECURITY_POSTURE_AND_TESTING.md
@@ -78,6 +78,25 @@ The Rust test suite covers:
 - end-to-end v2 app install, launch, status, doctor, and login flows
 - direct-exec fallback, unsupported-domain handling, denial handling, and malformed broker response mapping
 
+The native app Swift test suite covers:
+
+- localized approval prompt copy for APW-owned UI
+- accessibility labels for the credential approval window and buttons
+- broker envelope parsing, permission checks, denial handling, and typed AuthenticationServices fallback errors
+
+## Accessibility and localization audit
+
+Rerun this checklist before each minor release and when changing APW-owned UI.
+Apple-owned AuthenticationServices picker UI is out of scope for direct labels,
+but the APW surfaces around it remain in scope.
+
+- VoiceOver announces the APW credential approval window with a clear label.
+- VoiceOver announces Allow and Deny buttons with action-oriented labels.
+- Keyboard-only users can reach and activate every APW-owned approval control.
+- APW-owned user-visible strings are loaded from `Localizable.strings`.
+- At least one non-English `.lproj` resource ships in `APW.app`.
+- Reduced motion, high contrast, and increased text size do not hide or truncate APW-owned approval text.
+
 ## Archive policy
 
 The Deno implementation is archived and not part of the supported security

--- a/native-app/Package.swift
+++ b/native-app/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "APW",
+    defaultLocalization: "en",
     platforms: [
         .macOS(.v13),
     ],
@@ -13,7 +14,10 @@ let package = Package(
     targets: [
         .target(
             name: "NativeAppLib",
-            path: "Sources/NativeAppLib"
+            path: "Sources/NativeAppLib",
+            resources: [
+                .process("Resources"),
+            ]
         ),
         .executableTarget(
             name: "APW",

--- a/native-app/Sources/NativeAppLib/BrokerCore.swift
+++ b/native-app/Sources/NativeAppLib/BrokerCore.swift
@@ -55,16 +55,108 @@ protocol ApprovalPrompter {
   func prompt(url: String, username: String) -> Bool
 }
 
+struct ApprovalPromptContent {
+  let messageText: String
+  let informativeText: String
+  let allowButtonTitle: String
+  let denyButtonTitle: String
+  let windowAccessibilityLabel: String
+  let allowAccessibilityLabel: String
+  let denyAccessibilityLabel: String
+}
+
+func nativeAppResourceBundle() -> Bundle {
+  if let url = Bundle.main.url(forResource: "APW_NativeAppLib", withExtension: "bundle"),
+    let bundle = Bundle(url: url)
+  {
+    return bundle
+  }
+  let rootBundlePath = Bundle.main.bundleURL
+    .appendingPathComponent("APW_NativeAppLib.bundle")
+    .path
+  if let bundle = Bundle(path: rootBundlePath) {
+    return bundle
+  }
+  return .module
+}
+
+func nativeAppLocalizationBundle(
+  for locale: String,
+  baseBundle: Bundle = nativeAppResourceBundle()
+) -> Bundle? {
+  guard let path = baseBundle.path(forResource: locale, ofType: "lproj") else {
+    return nil
+  }
+  return Bundle(path: path)
+}
+
+func nativeAppLocalizedString(
+  _ key: String,
+  fallback: String,
+  bundle: Bundle = nativeAppResourceBundle()
+) -> String {
+  bundle.localizedString(forKey: key, value: fallback, table: nil)
+}
+
+func approvalPromptContent(
+  url: String,
+  username: String,
+  bundle: Bundle = nativeAppResourceBundle()
+) -> ApprovalPromptContent {
+  let informativeTemplate = nativeAppLocalizedString(
+    "approval.informativeText",
+    fallback: "Return the bootstrap credential for %@ as %@?",
+    bundle: bundle
+  )
+  return ApprovalPromptContent(
+    messageText: nativeAppLocalizedString(
+      "approval.messageText",
+      fallback: "Allow APW login?",
+      bundle: bundle
+    ),
+    informativeText: String(format: informativeTemplate, url, username),
+    allowButtonTitle: nativeAppLocalizedString(
+      "approval.allowButton",
+      fallback: "Allow",
+      bundle: bundle
+    ),
+    denyButtonTitle: nativeAppLocalizedString(
+      "approval.denyButton",
+      fallback: "Deny",
+      bundle: bundle
+    ),
+    windowAccessibilityLabel: nativeAppLocalizedString(
+      "approval.accessibility.window",
+      fallback: "APW credential approval",
+      bundle: bundle
+    ),
+    allowAccessibilityLabel: nativeAppLocalizedString(
+      "approval.accessibility.allow",
+      fallback: "Allow APW to return the selected credential",
+      bundle: bundle
+    ),
+    denyAccessibilityLabel: nativeAppLocalizedString(
+      "approval.accessibility.deny",
+      fallback: "Deny the APW credential request",
+      bundle: bundle
+    )
+  )
+}
+
 struct SystemApprovalPrompter: ApprovalPrompter {
   func prompt(url: String, username: String) -> Bool {
     _ = ASCredentialIdentityStore.shared
     NSApplication.shared.setActivationPolicy(.accessory)
+    let content = approvalPromptContent(url: url, username: username)
     let alert = NSAlert()
-    alert.messageText = "Allow APW login?"
-    alert.informativeText = "Return the bootstrap credential for \(url) as \(username)?"
+    alert.messageText = content.messageText
+    alert.informativeText = content.informativeText
     alert.alertStyle = .informational
-    alert.addButton(withTitle: "Allow")
-    alert.addButton(withTitle: "Deny")
+    alert.addButton(withTitle: content.allowButtonTitle)
+    alert.addButton(withTitle: content.denyButtonTitle)
+    alert.window.setAccessibilityLabel(content.windowAccessibilityLabel)
+    alert.buttons.first?.setAccessibilityLabel(content.allowAccessibilityLabel)
+    alert.buttons.dropFirst().first?.setAccessibilityLabel(content.denyAccessibilityLabel)
     NSApp.activate(ignoringOtherApps: true)
     return alert.runModal() == .alertFirstButtonReturn
   }

--- a/native-app/Sources/NativeAppLib/Resources/en.lproj/Localizable.strings
+++ b/native-app/Sources/NativeAppLib/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+"approval.messageText" = "Allow APW login?";
+"approval.informativeText" = "Return the bootstrap credential for %@ as %@?";
+"approval.allowButton" = "Allow";
+"approval.denyButton" = "Deny";
+"approval.accessibility.window" = "APW credential approval";
+"approval.accessibility.allow" = "Allow APW to return the selected credential";
+"approval.accessibility.deny" = "Deny the APW credential request";

--- a/native-app/Sources/NativeAppLib/Resources/es.lproj/Localizable.strings
+++ b/native-app/Sources/NativeAppLib/Resources/es.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+"approval.messageText" = "Autorizar inicio de sesion de APW?";
+"approval.informativeText" = "Devolver la credencial bootstrap para %@ como %@?";
+"approval.allowButton" = "Permitir";
+"approval.denyButton" = "Denegar";
+"approval.accessibility.window" = "Aprobacion de credenciales de APW";
+"approval.accessibility.allow" = "Permitir que APW devuelva la credencial seleccionada";
+"approval.accessibility.deny" = "Denegar la solicitud de credenciales de APW";

--- a/native-app/Tests/NativeAppTests/BrokerCoreTests.swift
+++ b/native-app/Tests/NativeAppTests/BrokerCoreTests.swift
@@ -175,6 +175,24 @@ final class BrokerCoreTests: XCTestCase {
     XCTAssertEqual(denyResponse.error, "User denied the APW login request.")
   }
 
+  func testApprovalPromptContentLoadsLocalizedStringsAndAccessibilityLabels() throws {
+    let spanishBundle = try XCTUnwrap(nativeAppLocalizationBundle(for: "es"))
+    let content = approvalPromptContent(
+      url: "https://example.com",
+      username: "demo@example.com",
+      bundle: spanishBundle
+    )
+
+    XCTAssertEqual(content.messageText, "Autorizar inicio de sesion de APW?")
+    XCTAssertEqual(content.allowButtonTitle, "Permitir")
+    XCTAssertEqual(content.denyButtonTitle, "Denegar")
+    XCTAssertTrue(content.informativeText.contains("https://example.com"))
+    XCTAssertTrue(content.informativeText.contains("demo@example.com"))
+    XCTAssertFalse(content.windowAccessibilityLabel.isEmpty)
+    XCTAssertFalse(content.allowAccessibilityLabel.isEmpty)
+    XCTAssertFalse(content.denyAccessibilityLabel.isEmpty)
+  }
+
   func testLoginWithoutDemoEnvReturnsNoCredentialSource() throws {
     let root = URL(fileURLWithPath: NSTemporaryDirectory())
       .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/scripts/build-native-app.sh
+++ b/scripts/build-native-app.sh
@@ -9,6 +9,7 @@ DIST_DIR="$PACKAGE_DIR/dist"
 APP_DIR="$DIST_DIR/$APP_NAME"
 CONTENTS_DIR="$APP_DIR/Contents"
 MACOS_DIR="$CONTENTS_DIR/MacOS"
+RESOURCES_DIR="$CONTENTS_DIR/Resources"
 PLIST_PATH="$CONTENTS_DIR/Info.plist"
 EXECUTABLE_PATH="$PACKAGE_DIR/.build/release/$EXECUTABLE_NAME"
 VERSION="$(awk -F ' = ' '$1 == "version" { gsub(/"/, "", $2); print $2; exit }' "$ROOT_DIR/rust/Cargo.toml")"
@@ -21,9 +22,14 @@ fi
 swift build --package-path "$PACKAGE_DIR" -c release
 
 rm -rf "$APP_DIR"
-mkdir -p "$MACOS_DIR"
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
 cp "$EXECUTABLE_PATH" "$MACOS_DIR/$EXECUTABLE_NAME"
 chmod 0755 "$MACOS_DIR/$EXECUTABLE_NAME"
+
+RESOURCE_BUNDLE="$(find "$PACKAGE_DIR/.build" -path '*/release/*.bundle' -type d -name '*NativeAppLib*.bundle' | head -n 1 || true)"
+if [[ -n "$RESOURCE_BUNDLE" ]]; then
+  cp -R "$RESOURCE_BUNDLE" "$RESOURCES_DIR/$(basename "$RESOURCE_BUNDLE")"
+fi
 
 cat >"$PLIST_PATH" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary

- Closes #54 by localizing APW-owned credential approval prompt copy and button titles.
- Adds accessibility labels for the APW approval alert and Allow/Deny controls.
- Ships English and Spanish `Localizable.strings` resources in the SwiftPM target and copies the generated resource bundle into `APW.app`.
- Documents the accessibility/localization release checklist in `docs/SECURITY_POSTURE_AND_TESTING.md`.

## Verification

- `swift test --package-path native-app` (outside sandbox; Swift module caches require user cache writes)
- `./scripts/build-native-app.sh` (outside sandbox)
- `find native-app/dist/APW.app/Contents -maxdepth 4 -type f -o -type d | sort | sed -n '1,120p'` confirmed `en.lproj` and `es.lproj` resources ship in the bundle
- `bash scripts/ci/run-fast-checks.sh`
- `git diff --check`

## Notes

- Swift emits the existing AuthenticationServices exhaustiveness warning in `AuthenticationServicesBroker.swift`; this PR does not change that switch.
