### PR TITLE
Refresh v2 threat model

### DIFF
--- a/docs/SECURITY_POSTURE_AND_TESTING.md
+++ b/docs/SECURITY_POSTURE_AND_TESTING.md
@@ -77,6 +77,18 @@ The Rust test suite covers:
 - native app diagnostics and `APW_DEMO=1` bootstrap credential file initialization
 - end-to-end v2 app install, launch, status, doctor, and login flows
 - direct-exec fallback, unsupported-domain handling, denial handling, and malformed broker response mapping
+- external fallback provider path hardening, including relative paths, `~`, world-writable
+  executables, and symlink targets
+- diagnostic-bundle redaction and fail-closed aborts when staged diagnostics look
+  credential-like
+- threat-model drift checks so retired UDP/browser-helper/private-helper
+  surfaces do not re-enter the supported v2 broker boundary without an explicit
+  documentation update
+
+The threat matrix and residual-risk owners are tracked in
+[THREAT_MODEL.md](THREAT_MODEL.md). When a new credential surface is added,
+update that matrix and add a focused regression in the Rust or Swift suite that
+proves the documented mitigation.
 
 ## Archive policy
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,49 +1,93 @@
 # APW threat model
 
-This document describes the APW v2 credential-broker security boundary.
+This document describes the supported APW v2 credential-broker security
+boundary after the native-app cutover.
 
-Release reference version: `v2.0.0`
+Release reference version: `v2.1.0` planning baseline
 
 ## Assets
 
 - iCloud Keychain password credentials for app-associated domains.
-- Same-user broker requests and responses over the local APW socket.
+- Same-user broker requests and responses between the Rust CLI and `APW.app`.
 - APW runtime config under `~/.apw/config.json`.
+- Associated-domain entitlement and AASA state used to decide which domains
+  the app may request from Apple Passwords.
 - Optional external password-manager fallback output.
+- Release artifacts, signatures, notarization tickets, and install packages.
 
 APW is scoped to credentials the signed macOS app is entitled to request through
 Apple associated-domain and AuthenticationServices policy. Domains outside the
-embedded entitlements are out of scope for credential access.
+embedded entitlement are out of scope for credential access.
 
 ## Trust boundaries
 
-- CLI to native app: same-user local IPC under `~/.apw/native-app/`.
-- Native app to Apple Passwords: public Apple frameworks and system-mediated
-  credential UI.
+- CLI to native app: same-user local UNIX socket under
+  `~/.apw/native-app/`. The socket is local-only, permission checked, and
+  bounded by request and response size limits. `NSXPCConnection` was considered
+  in the redesign notes, but the current supported transport is the UNIX socket.
+- Native app to Apple Passwords: public AuthenticationServices APIs and
+  system-mediated credential UI. Credential release must remain user mediated.
+- Associated-domain trust input: the app's signed entitlement and each
+  domain's AASA file determine which hosts can be requested.
 - CLI to external fallback provider: opt-in subprocess execution from an
-  absolute configured path.
+  absolute configured path, enabled only by an explicit command flag.
+- Runtime files: same-user `~/.apw` state stores config and status metadata but
+  must not persist plaintext user credentials by default.
 - Repository to release artifact: build, signing, notarization, and package
   publication gates.
+
+## Retired surfaces
+
+The UDP daemon listener, browser-extension bridge, and private native-host
+helper launch path are legacy compatibility surfaces. They are not part of the
+supported v2 credential-broker boundary and must not receive new feature work.
+Archive/removal is tracked in issue #47, with command removal tracked in issue
+#46. Until those changes land, tests may keep compatibility behavior
+reproducible, but release security claims should be made against the native app
+broker, not the legacy daemon.
 
 ## Attacker models
 
 - Local unprivileged user on the same machine attempting cross-user credential
   access.
+- Same-user malicious process attempting to impersonate the broker socket,
+  replay a credential response, or tamper with runtime files.
 - Malicious or corrupted `~/.apw/config.json` attempting to redirect fallback
-  provider execution.
-- Rogue local process attempting to impersonate the broker socket or replay a
-  credential response.
-- Operator error during domain expansion, signing, notarization, or release
-  packaging.
+  provider execution or claim unsupported domains.
+- Compromised external password-manager CLI or shim returning malformed,
+  oversized, or unexpected output.
+- Operator error during domain expansion, signing, notarization, diagnostic
+  bundle export, or release packaging.
 
-## In scope
+## Threat matrix
 
-- Rejecting unsupported domains before a credential is returned.
-- Returning typed failures for malformed IPC, unsupported URLs, denied requests,
-  and broker timeouts.
-- Keeping broker and runtime files same-user scoped.
-- Requiring explicit user mediation before credential release.
-- Validating external fallback provider configuration before execution.
+| Threat | Mitigation | Residual risk or follow-up |
+| --- | --- | --- |
+| Unsupported domain asks for a credential | URL host validation, associated-domain entitlement scoping, config allowed only to narrow the active domain set, and `apw doctor` AASA checks | Production-domain validation remains tracked by issue #8 and real-hardware validation by issue #43 |
+| Broker socket spoofing or replay | Same-user runtime directory, socket type and permission checks before connect, bounded request/response sizes, typed request IDs, and timeouts | Same-user malware can still observe user-owned processes; this is out of scope for APW |
+| Malformed or oversized broker response | JSON envelope validation, maximum response size, typed error mapping, and regression coverage | Keep new broker commands on the same envelope |
+| User cancels, denies, or times out in AuthenticationServices | Stable broker error codes and messages, no credential persistence on failure, and `userMediated: true` on success | Real notarized host coverage is tracked by issue #43 |
+| External fallback path hijack | Requires config plus explicit `--external-fallback`, rejects relative and `~` paths, validates executable permissions through symlink targets, uses bounded reads and process-group timeouts, and marks payloads `securityMode: reduced_external_cli` | External providers are an accepted reduced-security mode, not equivalent to Apple Passwords mediation |
+| Runtime config tampering | `~/.apw` and generated files use owner-only permissions, config contains routing metadata rather than plaintext credentials, and managed config is tracked separately | Enterprise override policy is tracked by issue #51 |
+| AASA or entitlement drift | Domain expansion playbook documents entitlement, AASA, signing, notarization, and doctor validation steps | Wildcard/multi-tenant entitlement strategy remains future work under issue #8 |
+| Diagnostic bundle leaks secrets | Bundle export excludes credential/config/log files, audits every staged string for token-like data, aborts fail-closed, and writes archives mode `0600` | Keep new diagnostic fields behind the same redaction audit |
+| Release artifact tampering | Release gates include build, test, signing, notarization, package verification, and universal-binary checks | Notarization automation is tracked by issue #7; universal checks by issue #53 |
+
+## Security regression map
+
+- `rust/tests/security_regressions.rs` covers invalid inputs, launch failure
+  precedence, stable status shape, fallback provider path hardening, and this
+  threat-model drift guard.
+- `rust/src/native_app.rs` unit tests cover socket safety, stale socket
+  fallback, timeout handling, direct-exec fallback, and external provider
+  parsing.
+- `rust/tests/native_app_e2e.rs` covers native app install, launch, doctor,
+  login, diagnostic-bundle redaction, and fail-closed bundle export behavior.
+- `native-app/Tests/NativeAppTests/BrokerCoreTests.swift` covers the
+  AuthenticationServices broker routing contract with injected success and
+  denial outcomes.
+- `docs/SECURITY_POSTURE_AND_TESTING.md` lists the release gates that must stay
+  aligned with this threat model.
 
 ## Out of scope
 
@@ -65,4 +109,5 @@ Adding a production domain requires all of these steps:
    publishing.
 
 Config may narrow the active domain set, but it must not claim domains beyond
-the embedded entitlement.
+the embedded entitlement. The operator playbook is
+[DOMAIN_EXPANSION.md](DOMAIN_EXPANSION.md).

--- a/rust/tests/security_regressions.rs
+++ b/rust/tests/security_regressions.rs
@@ -48,6 +48,12 @@ fn parse_json_output(value: &str) -> Value {
     serde_json::from_str(value).unwrap_or_else(|_| panic!("expected json response, got {}", value))
 }
 
+fn repo_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("rust crate should live under repo root")
+}
+
 fn write_launch_failure_config(home: &Path, last_launch_error: &str) {
     let config = serde_json::json!({
         "schema": 1,
@@ -141,6 +147,45 @@ print(json.dumps({"ok": False, "code": 3, "error": "no credential"}))
     .expect("failed to write native app executable");
     fs::set_permissions(&executable, fs::Permissions::from_mode(0o755))
         .expect("failed to chmod native app executable");
+}
+
+#[test]
+fn threat_model_documents_current_v2_security_boundary() {
+    let threat_model = fs::read_to_string(repo_root().join("docs/THREAT_MODEL.md"))
+        .expect("failed to read threat model");
+    let posture = fs::read_to_string(repo_root().join("docs/SECURITY_POSTURE_AND_TESTING.md"))
+        .expect("failed to read security posture doc");
+
+    for required in [
+        "AuthenticationServices",
+        "associated-domain",
+        "external fallback",
+        "UNIX socket",
+        "Retired surfaces",
+        "supported v2 credential-broker boundary",
+        "Security regression map",
+    ] {
+        assert!(
+            threat_model.contains(required),
+            "threat model should document {required}"
+        );
+    }
+
+    for retired in [
+        "UDP listener attack surface",
+        "Browser-extension trust boundary",
+        "Apple's private-helper launch path",
+    ] {
+        assert!(
+            !threat_model.contains(retired),
+            "threat model should not describe retired legacy surface `{retired}` as current"
+        );
+    }
+
+    assert!(
+        posture.contains("threat-model drift checks"),
+        "security posture should list the threat-model drift regression"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Refreshes `docs/THREAT_MODEL.md` for the supported v2 native-app broker boundary after the cutover.
- Documents retired UDP daemon, browser bridge, and private helper surfaces as legacy-only, with residual-risk owners and follow-up issues.
- Cross-links the security posture coverage list and adds a Rust regression that guards against threat-model drift.

Closes #55.

## Verification

- `cargo fmt --manifest-path rust/Cargo.toml -- --check`
- `cargo test --manifest-path rust/Cargo.toml --test security_regressions threat_model_documents_current_v2_security_boundary -- --nocapture`
- `cargo test --manifest-path rust/Cargo.toml --test security_regressions`
- `bash scripts/ci/run-fast-checks.sh`
- `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`

## Notes

- Mutation testing / CRAP indicator coverage is being handled in the dedicated quality branch/PR already open for that repo-wide gate; this PR adds the issue-specific security regression guard requested by #55.
