### PR TITLE
Add repository security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are prepared for the maintained Rust-first `v2` line. The
+historical Deno implementation under `legacy/deno/` and the archived browser
+bridge are retained only for compatibility audits and do not receive new
+security fixes.
+
+| Version line | Supported |
+| --- | --- |
+| `v2.x` | Yes |
+| `v1.x` compatibility paths | Best-effort migration support only |
+| `legacy/deno/` | No |
+| `browser-bridge/` archive | No |
+
+## Reporting a Vulnerability
+
+Report suspected vulnerabilities privately through GitHub Security Advisories
+for `OMT-Global/apw-cli`. Include:
+
+- affected APW version or commit,
+- operating system and architecture,
+- whether `APW_DEMO=1` or `--external-fallback` was used,
+- exact command or broker request shape,
+- impact and any known credential exposure path,
+- safe reproduction steps that do not include real secrets.
+
+Do not open a public issue with exploit details, credentials, tokens, private
+domains, or machine-local paths.
+
+## Security Scope
+
+In scope:
+
+- the Rust CLI in `rust/`,
+- the native macOS app broker in `native-app/`,
+- local broker IPC, request/response envelopes, and timeout behavior,
+- associated-domain and AASA validation paths,
+- release packaging, signing, notarization, and install surfaces,
+- explicit external password-manager fallback execution.
+
+Out of scope:
+
+- cross-user access to another macOS account's keychain,
+- vulnerabilities in Apple Passwords or AuthenticationServices,
+- secrets intentionally returned by a configured external fallback provider,
+- archived legacy implementations except where they affect the maintained `v2`
+  line.
+
+## Disclosure Expectations
+
+Maintainers will acknowledge valid reports as soon as practical, assess the
+affected surface, and coordinate a fix before public disclosure. Security
+release checks should include the gates in
+[`docs/SECURITY_POSTURE_AND_TESTING.md`](docs/SECURITY_POSTURE_AND_TESTING.md)
+and the current threat model in [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md).

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -25,6 +25,7 @@
     - Confirm branch protection points at the `CI Gate` status.
     - Confirm `delete branch on merge` and `allow auto-merge` are enabled.
     - Confirm projects and wiki are disabled in live repository settings.
+    - Confirm the GitHub Security Policy surface is enabled from `SECURITY.md`.
     - Confirm `dev`, `stage`, and `prod` GitHub environments exist with the reviewer gates described below.
 
     ## Environments

--- a/project.bootstrap.yaml
+++ b/project.bootstrap.yaml
@@ -12,6 +12,7 @@ repo:
     - AGENTS.md
     - CLAUDE.md
     - CODEOWNERS
+    - SECURITY.md
     - .githooks/**
     - .devcontainer/**
     - .github/workflows/pr-fast-ci.yml
@@ -26,7 +27,7 @@ repo:
   docs:
     readme: true
     contributing: false
-    security: false
+    security: true
   templates:
     pullRequest: standard
     issueTemplates:

--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -21,6 +21,11 @@ if [ ! -x scripts/render-homebrew-formula.sh ]; then
   exit 1
 fi
 
+if grep -Eq '^[[:space:]]+security:[[:space:]]+true[[:space:]]*$' project.bootstrap.yaml && [ ! -f SECURITY.md ]; then
+  echo "project.bootstrap.yaml enables docs.security but SECURITY.md is missing." >&2
+  exit 1
+fi
+
 chmod +x ./.github/scripts/verify-version-sync.sh
 ./.github/scripts/verify-version-sync.sh \
   rust/Cargo.toml \


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md` so GitHub can expose the repository Security Policy surface after merge.
- Aligns `project.bootstrap.yaml` with that governance state by marking `docs.security: true` and managing `SECURITY.md`.
- Adds a fast-check guard so the bootstrap manifest cannot enable the security policy without the corresponding file.
- Updates bootstrap onboarding verification to include the GitHub Security Policy surface.

Closes #17.

## Verification

- `bash scripts/ci/run-fast-checks.sh`
- `bash -n scripts/ci/run-fast-checks.sh`
- `git diff --check`

## Live Governance Check

Before this PR, live GitHub state already matched the other #17 acceptance points I checked:

- `main` branch protection requires `CI Gate`.
- Required PR reviews require 1 approval, code-owner review, stale-review dismissal, and no last-push approval.
- `deleteBranchOnMerge=true`, projects disabled, wiki disabled, discussions disabled.
- `dev`, `stage`, and `prod` environments exist; `stage` and `prod` require reviewer gates.

The remaining durable gap was `isSecurityPolicyEnabled=false`, which GitHub derives from a security policy file on the default branch.
