### PR TITLE
Fix PR #62: harden bundle redaction for object keys and embedded vendor prefixes

### DIFF
--- a/rust/src/bundle.rs
+++ b/rust/src/bundle.rs
@@ -598,7 +598,9 @@ mod tests {
         // Vendor prefix embedded inside a longer diagnostic string must be caught.
         assert!(looks_secret_like("token=ghp_abc123def456ghi789jkl0"));
         assert!(looks_secret_like("auth failed for sk-abc123"));
-        assert!(looks_secret_like("header: Authorization: Bearer AKIA1234EXAMPLE"));
+        assert!(looks_secret_like(
+            "header: Authorization: Bearer AKIA1234EXAMPLE"
+        ));
     }
 
     #[test]

--- a/rust/src/bundle.rs
+++ b/rust/src/bundle.rs
@@ -291,7 +291,8 @@ where
             Ok(())
         }
         Value::Object(map) => {
-            for (_, item) in map {
+            for (key, item) in map {
+                f(key)?;
                 walk_strings(item, f)?;
             }
             Ok(())
@@ -353,7 +354,7 @@ fn looks_secret_like(value: &str) -> bool {
         "pk_live_",
     ];
     for prefix in TOKEN_PREFIXES {
-        if trimmed.starts_with(prefix) {
+        if trimmed.contains(prefix) {
             return true;
         }
     }
@@ -588,6 +589,26 @@ mod tests {
         });
         let mut count = 0;
         let err = audit_redaction(&payload, &mut count).expect_err("must abort");
+        assert_eq!(err.code, Status::InvalidConfig);
+        assert!(err.message.contains("Aborting bundle"));
+    }
+
+    #[test]
+    fn looks_secret_like_flags_embedded_vendor_prefix() {
+        // Vendor prefix embedded inside a longer diagnostic string must be caught.
+        assert!(looks_secret_like("token=ghp_abc123def456ghi789jkl0"));
+        assert!(looks_secret_like("auth failed for sk-abc123"));
+        assert!(looks_secret_like("header: Authorization: Bearer AKIA1234EXAMPLE"));
+    }
+
+    #[test]
+    fn audit_redaction_fails_closed_on_secret_like_object_key() {
+        // A secret-shaped string used as a JSON object key must be caught.
+        let payload = json!({
+            "ghp_abc123def456ghi789jkl0": "some value",
+        });
+        let mut count = 0;
+        let err = audit_redaction(&payload, &mut count).expect_err("must abort on secret key");
         assert_eq!(err.code, Status::InvalidConfig);
         assert!(err.message.contains("Aborting bundle"));
     }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes two redaction bypass paths identified in PR #62 review:

- **Object keys not scanned**: `walk_strings` destructured map entries as `(_, item)`, silently discarding every key. A secret-shaped string used as a JSON key (e.g. from an externally-sourced broker status payload) would reach the archive undetected. Keys are now passed through the same audit closure as values.

- **Vendor prefix only matched at start of string**: `looks_secret_like` used `starts_with` for the `TOKEN_PREFIXES` check, so strings like `"token=ghp_abc123..."` or `"auth failed for sk-..."` passed the heuristic even though they contain obvious credential markers. Changed to `contains` so embedded prefixes in free-text diagnostics are caught.

## Changes

- `rust/src/bundle.rs` — two-line targeted fixes to `walk_strings` and `looks_secret_like`
- Two new unit tests:
  - `looks_secret_like_flags_embedded_vendor_prefix` — verifies vendor prefixes embedded in longer strings are detected
  - `audit_redaction_fails_closed_on_secret_like_object_key` — verifies secret-like object keys abort the bundle

## Test plan

- [x] `cargo test bundle::tests` — all 7 tests pass (including the 2 new regressions)

https://claude.ai/code/session_014vi2BJwoGVh6bLEEo35XT8
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014vi2BJwoGVh6bLEEo35XT8)_