### PR TITLE
Add project vision document

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,34 @@
+# APW CLI Vision
+
+Version: 0.1
+
+APW CLI is a focused command-line tool for agent and operator workflows that need reliable local execution, native-host awareness, and clear security boundaries.
+
+It should make common APW operations scriptable, inspectable, and safe to run repeatedly.
+
+## Who It Serves
+
+- Operators managing local APW workflows.
+- Agents repairing issues, checking state, and producing PRs.
+- Contributors who need a small CLI surface with strong tests and explicit host assumptions.
+
+## Product Principles
+
+- CLI behavior should be deterministic and easy to test.
+- Native-host limitations should be reported plainly.
+- Security review findings should become durable checks where possible.
+- Shell portability matters on macOS.
+- Every command should explain failure well enough for an agent to take the next step.
+
+## Near-Term Direction
+
+- Keep open PRs moving by resolving requested changes and stale labels.
+- Strengthen local checks around security-sensitive paths.
+- Reduce native-host ambiguity in command output and docs.
+- Maintain concise issue-backed slices.
+
+## Non-Goals
+
+- Do not grow the CLI into an unbounded workflow framework.
+- Do not rely on GNU-only shell behavior.
+- Do not treat read-only diagnosis as completed issue work.


### PR DESCRIPTION
## Summary

- Add an initial `VISION.md` for apw-cli.
- Capture the project audience, product principles, near-term direction, and non-goals.

## Governing Issue

- No issue is linked because this PR was created directly from the operator-injected request to seed first-draft project vision documents for review.
- This is documentation-only planning work and does not close a tracked implementation issue.

## Validation

- Not run; documentation-only change.

## Bootstrap Governance

- No bootstrap-managed files changed.
- No GitHub policy, runner, or repository settings changed.

## Merge Automation

- Not enabled. Please review and merge manually when the draft looks right.

## Notes

- Draft v0.1 for review and iteration in this PR.
