### PR TITLE
Require notarization for tagged releases

### DIFF
--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
-  group: pr-fast-${{ github.event.pull_request.number || github.ref }}
+  group: pr-fast-hosted-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -23,7 +23,7 @@ defaults:
 jobs:
   changes:
     name: Detect Relevant Changes
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ubuntu-latest
     outputs:
       app: ${{ steps.filter.outputs.app }}
       ci: ${{ steps.filter.outputs.ci }}
@@ -58,7 +58,7 @@ jobs:
 
   fast-checks:
     name: Fast Checks
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: changes
     if: >-
@@ -100,7 +100,7 @@ jobs:
 
   validate-secrets:
     name: Validate Secrets
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.event.pull_request.draft == false
     steps:
@@ -112,7 +112,7 @@ jobs:
 
   ci-gate:
     name: CI Gate
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ubuntu-latest
     if: always()
     needs:
       - changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
       - name: Sign and notarize native app bundle
         if: startsWith(github.ref, 'refs/tags/v')
         env:
+          APW_NOTARIZE_REQUIRED: "1"
           APPLE_DEVELOPER_CERT_P12: ${{ secrets.APPLE_DEVELOPER_CERT_P12 }}
           APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
           APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -92,10 +92,10 @@ contract, managed disable key, security-update marker, and release validation
 requirements are documented in [IN_APP_UPDATES.md](IN_APP_UPDATES.md).
 
 Tagged release archives are signed and notarized by
-`.github/workflows/release.yml` when the Apple Developer ID and notary secrets
-listed in `docs/bootstrap/onboarding.md` are configured. If those optional
-secrets are absent, the workflow emits a warning and publishes an unstapled
-archive rather than failing unrelated release automation.
+`.github/workflows/release.yml`. Tagged releases set
+`APW_NOTARIZE_REQUIRED=1`, so the workflow fails before publishing release
+artifacts when the Apple Developer ID or notary secrets listed in
+`docs/bootstrap/onboarding.md` are missing.
 
 ## Install from a release DMG
 

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -66,8 +66,8 @@
     ID certificate into a temporary keychain, signs the release CLI and
     `APW.app`, submits the app bundle to Apple notary service, staples the
     ticket, and verifies Gatekeeper assessment before the archive is packaged.
-    All Apple credentials are optional — when absent, the workflow emits a
-    `::warning::` and continues without notarization. The Homebrew tap job is
+    Tagged releases set `APW_NOTARIZE_REQUIRED=1`, so missing Apple credentials
+    fail the release before artifacts are published. The Homebrew tap job is
     `continue-on-error` so a missing or rejected token does not block the
     release.
 

--- a/scripts/test-notarize-native-app.sh
+++ b/scripts/test-notarize-native-app.sh
@@ -17,6 +17,11 @@ required_log="$tmp_dir/notary-required.log"
 optional_log="$tmp_dir/notary-optional.log"
 dry_run_log="$tmp_dir/notary-dry-run.log"
 
+grep -q "APW_NOTARIZE_REQUIRED: \"1\"" "$ROOT_DIR/.github/workflows/release.yml" || {
+  echo "release workflow must require notarization for tagged releases." >&2
+  exit 1
+}
+
 if APW_NOTARIZE_REQUIRED=1 APW_APP_BUNDLE_PATH="$fake_app" "$ROOT_DIR/scripts/notarize-native-app.sh" >"$required_log" 2>&1; then
   echo "notarize-native-app accepted missing required credentials." >&2
   exit 1


### PR DESCRIPTION
## Summary

- make tagged APW releases fail closed when Developer ID/notary credentials are missing
- add a regression check that the release workflow sets `APW_NOTARIZE_REQUIRED=1`
- update installation/onboarding docs so operators do not expect unsigned or unstapled tag assets to publish
- move shell-safe PR Fast CI jobs to hosted Ubuntu so the required `CI Gate` is not stranded when public self-hosted runners are unavailable
- move the PR Fast CI concurrency group to a hosted-runner namespace so stale self-hosted runs from the old workflow cannot hold the new hosted run

## Governing Issue

Refs #43
Refs #57
Refs #13

This does not close the remaining issues by itself. It removes a release-safety gap that would otherwise allow publishing artifacts that cannot satisfy the remaining notarized-host and signed-update acceptance proof.

## Validation

- `bash scripts/test-notarize-native-app.sh`
- `bash scripts/ci/run-fast-checks.sh`

## Bootstrap Governance

Release workflow behavior now matches the documented security-sensitive release contract: tagged releases require notarization before artifact publication.

The PR Fast CI shell-safe jobs still run the same repo scripts, but use GitHub-hosted Ubuntu. The macOS Swift test lane remains on the private macOS runner and is still path-gated to native-app changes.

## Merge Automation

Enable auto-merge once required checks and review policy are satisfied.

## Notes

Current live blockers for final issue closure remain external: GitHub currently has no APW releases, no configured repository secrets/variables for Apple notarization or Sparkle appcast generation were listed, and this local host has no valid code-signing identities.
