### PR TITLE
Require Sparkle config for tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,24 @@ jobs:
           cargo test --manifest-path rust/Cargo.toml
           cargo test --manifest-path rust/Cargo.toml --test security_regressions
 
+      - name: Validate tagged Sparkle release configuration
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          APW_SPARKLE_PUBLIC_ED_KEY: ${{ vars.APW_SPARKLE_PUBLIC_ED_KEY || '' }}
+          SPARKLE_GENERATE_APPCAST: ${{ vars.SPARKLE_GENERATE_APPCAST || '' }}
+        run: |
+          missing=()
+          if [ -z "$APW_SPARKLE_PUBLIC_ED_KEY" ]; then
+            missing+=("APW_SPARKLE_PUBLIC_ED_KEY")
+          fi
+          if [ -z "$SPARKLE_GENERATE_APPCAST" ]; then
+            missing+=("SPARKLE_GENERATE_APPCAST")
+          fi
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "Sparkle release configuration is incomplete; missing: ${missing[*]}" >&2
+            exit 1
+          fi
+
       - name: Build universal release binaries
         env:
           APW_SPARKLE_PUBLIC_ED_KEY: ${{ vars.APW_SPARKLE_PUBLIC_ED_KEY || '' }}
@@ -159,9 +177,8 @@ jobs:
           SPARKLE_GENERATE_APPCAST: ${{ vars.SPARKLE_GENERATE_APPCAST || '' }}
         run: |
           if [ -z "$SPARKLE_GENERATE_APPCAST" ]; then
-            echo "::warning::SPARKLE_GENERATE_APPCAST is not configured; skipping Sparkle appcast publication."
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "SPARKLE_GENERATE_APPCAST is required for tagged releases." >&2
+            exit 1
           fi
 
           app_zip="dist/APW.app-${GITHUB_REF_NAME}.zip"

--- a/docs/IN_APP_UPDATES.md
+++ b/docs/IN_APP_UPDATES.md
@@ -91,15 +91,13 @@ appcast does not contain EdDSA signatures or does not reference the release
 archive. Private EdDSA key material stays with Sparkle's configured signing
 environment, such as Keychain-backed release automation.
 
-Tagged releases run this helper when the release runner has the
-`SPARKLE_GENERATE_APPCAST` repository variable set to Sparkle's
-`generate_appcast` executable. When configured, the release attaches
-`appcast.xml` and the signed `APW.app` update archive to the GitHub release so
-the stable `/releases/latest/download/appcast.xml` feed URL resolves to a
-signed appcast. When the variable is absent, release automation emits a warning
-and skips appcast publication rather than inventing unsigned update metadata.
-Release runners should also set `APW_SPARKLE_PUBLIC_ED_KEY` to the public EdDSA
-key paired with the appcast signing key before enabling runtime update checks.
+Tagged releases run this helper only when the release runner has both
+`SPARKLE_GENERATE_APPCAST` set to Sparkle's `generate_appcast` executable and
+`APW_SPARKLE_PUBLIC_ED_KEY` set to the public EdDSA key paired with the appcast
+signing key. Tagged release automation fails before publishing when either
+value is missing. With both values present, the release attaches `appcast.xml`
+and the signed `APW.app` update archive to the GitHub release so the stable
+`/releases/latest/download/appcast.xml` feed URL resolves to a signed appcast.
 
 ## Managed update control
 

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -62,12 +62,19 @@
     | `APPLE_NOTARY_PRIVATE_KEY`   | base64-encoded `.p8` private key for `notarytool`              |
     | `HOMEBREW_TAP_TOKEN`         | scoped `contents:write` token on the tap repo (issue #6)       |
 
+    | Variable                    | Purpose                                                        |
+    | --------------------------- | -------------------------------------------------------------- |
+    | `APW_SPARKLE_PUBLIC_ED_KEY` | Sparkle EdDSA public key rendered into APW.app                  |
+    | `SPARKLE_GENERATE_APPCAST`  | path to Sparkle's `generate_appcast` executable on the runner   |
+
     On tagged releases, `scripts/notarize-native-app.sh` imports the Developer
     ID certificate into a temporary keychain, signs the release CLI and
     `APW.app`, submits the app bundle to Apple notary service, staples the
     ticket, and verifies Gatekeeper assessment before the archive is packaged.
     Tagged releases set `APW_NOTARIZE_REQUIRED=1`, so missing Apple credentials
-    fail the release before artifacts are published. The Homebrew tap job is
+    fail the release before artifacts are published. Tagged releases also
+    require the Sparkle variables above so release automation can publish a
+    signed appcast and configure APW.app to trust it. The Homebrew tap job is
     `continue-on-error` so a missing or rejected token does not block the
     release.
 

--- a/scripts/ci/validate-appcast-contract.sh
+++ b/scripts/ci/validate-appcast-contract.sh
@@ -62,6 +62,7 @@ require_pattern "$DOC_PATH" "prepare-sparkle-appcast\\.sh" "release appcast prep
 require_pattern "$DOC_PATH" "generate_appcast" "Sparkle appcast generation tool"
 require_pattern "$DOC_PATH" "SPARKLE_GENERATE_APPCAST" "release runner generate_appcast configuration"
 require_pattern "$DOC_PATH" "APW_SPARKLE_PUBLIC_ED_KEY" "release runner Sparkle public key configuration"
+require_pattern "$DOC_PATH" "fails before publishing" "tagged release fails without Sparkle config"
 require_pattern "$DOC_PATH" "SPUStandardUpdaterController" "runtime Sparkle updater controller"
 
 require_pattern "$TEMPLATE_PATH" "xmlns:sparkle=\"http://www\\.andymatuschak\\.org/xml-namespaces/sparkle\"" "Sparkle namespace"
@@ -120,6 +121,7 @@ require_pattern "$BUILD_NATIVE_APP" "@loader_path/\\.\\./Frameworks" "native app
 require_pattern "$RELEASE_WORKFLOW" "prepare-sparkle-appcast\\.sh" "release appcast preparation step"
 require_pattern "$RELEASE_WORKFLOW" "SPARKLE_GENERATE_APPCAST" "release appcast generator variable"
 require_pattern "$RELEASE_WORKFLOW" "APW_SPARKLE_PUBLIC_ED_KEY" "release Sparkle public key variable"
+require_pattern "$RELEASE_WORKFLOW" "Sparkle release configuration is incomplete" "tagged release Sparkle config fail-closed gate"
 require_pattern "$RELEASE_WORKFLOW" "dist/appcast\\.xml" "release appcast asset upload"
 require_pattern "$RELEASE_WORKFLOW" "APW\\.app-\\$\\{\\{ github\\.ref_name \\}\\}\\.zip" "release Sparkle app archive upload"
 


### PR DESCRIPTION
## Summary

- make tagged APW releases fail before publishing when Sparkle appcast tooling or the public EdDSA key is missing
- remove the release path that skipped appcast publication with only a warning
- extend the appcast contract validator and onboarding/update docs to cover the new fail-closed release gate

## Governing Issue

Refs #57
Refs #43
Refs #13

This does not close the remaining issues by itself. It prevents future tagged releases from publishing artifacts that cannot satisfy the signed-appcast and notarized-update proof required for #57, which is also part of the real-host closure path for #13/#43.

## Validation

- `bash scripts/ci/validate-appcast-contract.sh`
- `bash scripts/ci/run-fast-checks.sh`

## Bootstrap Governance

Release automation now requires both notarization configuration and Sparkle update-channel configuration for tagged releases before artifacts can publish.

## Merge Automation

Enable auto-merge once required checks and review policy are satisfied.

## Notes

Current live blockers for final issue closure remain external: the repository still has no listed APW releases, no listed Apple/Sparkle release secrets or variables, and this local host has no valid code-signing identities.
