### PR TITLE
Use hosted runners for extended shell jobs

### DIFF
--- a/.github/workflows/extended-validation.yml
+++ b/.github/workflows/extended-validation.yml
@@ -25,7 +25,7 @@ defaults:
 jobs:
   changes:
     name: Detect Extended Validation Scope
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ubuntu-latest
     outputs:
       app: ${{ steps.preset.outputs.app || steps.filter.outputs.app || 'false' }}
       ci: ${{ steps.preset.outputs.ci || steps.filter.outputs.ci || 'false' }}
@@ -77,7 +77,7 @@ jobs:
 
   fast-checks:
     name: Fast Checks
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true'
@@ -111,7 +111,7 @@ jobs:
 
   validate-secrets:
     name: Validate Secrets
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -120,7 +120,7 @@ jobs:
 
   extended-validation-gate:
     name: Extended Validation Gate
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ubuntu-latest
     if: always()
     needs:
       - changes


### PR DESCRIPTION
## Summary

- Move the shell-safe Extended Validation coordinator, fast check, secret scan, and gate jobs to `ubuntu-latest`.
- Keep the macOS/Xcode extended validation job on the private self-hosted macOS pool.
- Align post-merge shell-safe validation with the hosted PR Fast CI pattern already used by the repo.

## Verification

- `bash scripts/test-extended-validation-config.sh`
- `bash scripts/ci/run-fast-checks.sh`

## Notes

- This does not close #13, #43, or #57 by itself. It removes a post-merge validation queue risk observed after PR #87 while preserving the real external blockers: Apple signing/notary configuration, Sparkle release configuration, and notarized hardware validation proof.
