### PR TITLE
chore: assign CODEOWNERS to OMT-Codeowners team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-# Managed CODEOWNERS for OMT-Global native repos.
-* @pheidon @jmcte
+# OMT-Global code ownership
+* @OMT-Global/omt-codeowners


### PR DESCRIPTION
Assigns CODEOWNERS to the org-visible @OMT-Global/omt-codeowners team.

Team members now include pheidon, jmcte, and athena-omt; the team has write access to this repo so GitHub code-owner approval can satisfy branch protection and auto-merge gates.