### PR TITLE
Document scriptable app security posture

### DIFF
--- a/docs/SECURITY_POSTURE_AND_TESTING.md
+++ b/docs/SECURITY_POSTURE_AND_TESTING.md
@@ -46,6 +46,11 @@ Release reference version: `v2.0.0`
 - Shortcuts and AppleScript automation entrypoints build the same broker
   request envelope as CLI `apw login` / `apw fill`; they do not read credential
   material directly or bypass the broker's user-mediated response path
+- APW.app currently publishes those automation entrypoints without the App
+  Sandbox entitlement; this is a documented same-user local automation surface,
+  not a silent credential-release path. Issue #96 tracks whether to add App
+  Sandbox entitlements and prompt-fatigue rate limiting/coalescing before the
+  automation surface is broadened.
 - bootstrap credentials are read from a local runtime file for the supported
   demo domain only; the app does not create that plaintext file on default
   launch
@@ -145,7 +150,8 @@ The Rust test suite covers:
 - native app socket timeout handling
 - native app diagnostics and `APW_DEMO=1` bootstrap credential file initialization
 - end-to-end v2 app install, launch, status, doctor, and login flows
-- Shortcuts / AppleScript automation envelope parity for `login` and `fill`
+- Shortcuts / AppleScript automation envelope parity for `login` and `fill`,
+  including documentation drift checks for the unsandboxed scriptable surface
 - direct-exec fallback, unsupported-domain handling, denial handling, and malformed broker response mapping
 - signed appcast contract requirements for the future APW.app in-app update channel
 - a manual notarized-hardware validation contract for the Phase 3

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -9,6 +9,7 @@ Release reference version: `v2.1.0` planning baseline
 
 - iCloud Keychain password credentials for app-associated domains.
 - Same-user broker requests and responses between the Rust CLI and `APW.app`.
+- AppleScript and Shortcuts/AppIntents automation requests for `APW.app`.
 - APW runtime config under `~/.apw/config.json`.
 - Associated-domain entitlement and AASA state used to decide which domains
   the app may request from Apple Passwords.
@@ -27,6 +28,11 @@ embedded entitlement are out of scope for credential access.
   in the redesign notes, but the current supported transport is the UNIX socket.
 - Native app to Apple Passwords: public AuthenticationServices APIs and
   system-mediated credential UI. Credential release must remain user mediated.
+- Local automation to native app: `APW.app` intentionally publishes an
+  AppleScript dictionary and Shortcuts/AppIntents commands for `request login`
+  and `request fill`. These entrypoints are same-user local automation surfaces
+  and must preserve the same broker envelope, HTTPS validation, and
+  user-mediated credential release semantics as the CLI.
 - Associated-domain trust input: the app's signed entitlement and each
   domain's AASA file determine which hosts can be requested.
 - CLI to external fallback provider: opt-in subprocess execution from an
@@ -51,7 +57,8 @@ broker, not the legacy daemon.
 - Local unprivileged user on the same machine attempting cross-user credential
   access.
 - Same-user malicious process attempting to impersonate the broker socket,
-  replay a credential response, or tamper with runtime files.
+  replay a credential response, tamper with runtime files, or drive the
+  scriptable automation surface repeatedly to induce prompt fatigue.
 - Malicious or corrupted `~/.apw/config.json` attempting to redirect fallback
   provider execution or claim unsupported domains.
 - Compromised external password-manager CLI or shim returning malformed,
@@ -67,6 +74,7 @@ broker, not the legacy daemon.
 | Broker socket spoofing or replay | Same-user runtime directory, socket type and permission checks before connect, bounded request/response sizes, typed request IDs, and timeouts | Same-user malware can still observe user-owned processes; this is out of scope for APW |
 | Malformed or oversized broker response | JSON envelope validation, maximum response size, typed error mapping, and regression coverage | Keep new broker commands on the same envelope |
 | User cancels, denies, or times out in AuthenticationServices | Stable broker error codes and messages, no credential persistence on failure, and `userMediated: true` on success | Real notarized host coverage is tracked by issue #43 |
+| Same-user app drives AppleScript or Shortcuts requests repeatedly | Automation entrypoints route through the same broker request envelope and HTTPS validation as the CLI, the scripting dictionary documents user mediation, and credential release still depends on AuthenticationServices or APW-owned approval UI | `APW.app` is currently not sandboxed and has no automation rate limit/coalescing guard; issue #96 tracks whether to add App Sandbox entitlements and prompt-fatigue controls before broadening automation support |
 | External fallback path hijack | Requires config plus explicit `--external-fallback`, rejects relative and `~` paths, validates executable permissions through symlink targets, uses bounded reads and process-group timeouts, and marks payloads `securityMode: reduced_external_cli` | External providers are an accepted reduced-security mode, not equivalent to Apple Passwords mediation |
 | Runtime config tampering | `~/.apw` and generated files use owner-only permissions, config contains routing metadata rather than plaintext credentials, and managed config is tracked separately | Enterprise override policy is tracked by issue #51 |
 | AASA or entitlement drift | Domain expansion playbook documents entitlement, AASA, signing, notarization, and doctor validation steps | Wildcard/multi-tenant entitlement strategy remains future work under issue #8 |
@@ -85,7 +93,11 @@ broker, not the legacy daemon.
   login, diagnostic-bundle redaction, and fail-closed bundle export behavior.
 - `native-app/Tests/NativeAppTests/BrokerCoreTests.swift` covers the
   AuthenticationServices broker routing contract with injected success and
-  denial outcomes.
+  denial outcomes, plus automation envelope parity for AppleScript/Shortcuts
+  requests.
+- `scripts/test-native-automation-config.sh` checks that the scripting
+  dictionary, AppIntents, Info.plist, Swift bridge, and documented automation
+  risk posture stay aligned.
 - `docs/SECURITY_POSTURE_AND_TESTING.md` lists the release gates that must stay
   aligned with this threat model.
 

--- a/rust/tests/security_regressions.rs
+++ b/rust/tests/security_regressions.rs
@@ -162,6 +162,10 @@ fn threat_model_documents_current_v2_security_boundary() {
         "Retired surfaces",
         "supported v2 credential-broker boundary",
         "Security regression map",
+        "AppleScript and Shortcuts/AppIntents automation requests",
+        "prompt fatigue",
+        "not sandboxed",
+        "App Sandbox entitlements",
     ] {
         assert!(
             threat_model.contains(required),
@@ -183,6 +187,14 @@ fn threat_model_documents_current_v2_security_boundary() {
     assert!(
         posture.contains("threat-model drift checks"),
         "security posture should list the threat-model drift regression"
+    );
+    assert!(
+        posture.contains("without the App") && posture.contains("Sandbox entitlement"),
+        "security posture should document the current unsandboxed automation surface"
+    );
+    assert!(
+        posture.contains("rate limiting/coalescing"),
+        "security posture should track prompt-fatigue follow-up for automation"
     );
 }
 

--- a/scripts/test-native-automation-config.sh
+++ b/scripts/test-native-automation-config.sh
@@ -5,6 +5,9 @@ SDEF="native-app/Resources/APW.sdef"
 APP_INTENTS="native-app/Sources/APW/APWAutomationIntents.swift"
 APPLE_SCRIPT_COMMANDS="native-app/Sources/APW/APWAppleScriptCommands.swift"
 BROKER_CORE_TESTS="native-app/Tests/NativeAppTests/BrokerCoreTests.swift"
+THREAT_MODEL="docs/THREAT_MODEL.md"
+SECURITY_POSTURE="docs/SECURITY_POSTURE_AND_TESTING.md"
+ENTITLEMENTS="native-app/APW.entitlements"
 BUILD_SCRIPT="scripts/build-native-app.sh"
 PLIST_RENDERER="scripts/render-native-app-info-plist.sh"
 
@@ -53,6 +56,14 @@ require_line "$APPLE_SCRIPT_COMMANDS" "performOffMainThreadWhilePumpingRunLoop" 
 require_line "$BUILD_SCRIPT" 'cp "$PACKAGE_DIR/Resources/APW.sdef" "$RESOURCES_DIR/APW.sdef"' "APW.sdef must be copied into the app bundle."
 require_line "$PLIST_RENDERER" "<key>NSAppleScriptEnabled</key>" "App bundle must enable AppleScript."
 require_line "$PLIST_RENDERER" "<key>OSAScriptingDefinition</key>" "App bundle must publish the scripting definition."
+if grep -Fq "com.apple.security.app-sandbox" "$ENTITLEMENTS"; then
+  require_line "$THREAT_MODEL" "App Sandbox" "Threat model must describe the sandboxed automation posture when sandbox entitlement is present."
+else
+  require_line "$THREAT_MODEL" "not sandboxed" "Threat model must document APW.app automation when App Sandbox is absent."
+  require_line "$THREAT_MODEL" "prompt fatigue" "Threat model must document prompt-fatigue risk for scriptable automation."
+  require_line "$SECURITY_POSTURE" "without the App" "Security posture must document the current unsandboxed automation surface."
+  require_line "$SECURITY_POSTURE" "rate limiting/coalescing" "Security posture must track prompt-fatigue rate limiting or coalescing follow-up."
+fi
 require_line "native-app/Sources/NativeAppLib/BrokerCore.swift" "runScriptableBrokerApp" "Scriptable app launches must run an AppKit event loop."
 require_line "native-app/Sources/NativeAppLib/BrokerCore.swift" "NSApplication.shared" "Scriptable app launches must initialize NSApplication."
 


### PR DESCRIPTION
## Summary
- document APW.app AppleScript and Shortcuts/AppIntents surface in the threat model
- record the current unsandboxed posture and prompt-fatigue follow-up for #96
- extend automation config and threat-model drift checks so docs stay aligned with entitlements

Fixes #96

## Tests
- ./scripts/test-native-automation-config.sh
- cargo test --manifest-path rust/Cargo.toml threat_model_documents_current_v2_security_boundary
